### PR TITLE
doc: add repository section

### DIFF
--- a/src/main/docs/guide/repository.adoc
+++ b/src/main/docs/guide/repository.adoc
@@ -1,0 +1,3 @@
+You can find the source code of this project in this repository:
+
+https://github.com/{githubSlug}[https://github.com/{githubSlug}]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,5 +3,5 @@ introduction:
   releaseHistory: Release History
 quickStart:
   title: Quick Start
-
+repository: Repository
 


### PR DESCRIPTION
It creates a section at the bottom of the docs such as: 

![Screenshot 2020-07-22 at 17 47 45](https://user-images.githubusercontent.com/864788/88198544-19bed280-cc44-11ea-9db6-717ecc68cbb3.png)
