### PR TITLE
Enforce javadoc on classes

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,6 +96,7 @@
         </module>
         <module name="JavadocType"/>
         <module name="JavadocStyle"/>
+        <module name="MissingJavadocType"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->


### PR DESCRIPTION
Without this classes with no javadoc at all don't cause checkstyle errors