### PR TITLE
Exclude 'MissingJavadocType' rule for doc-examples

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -7,4 +7,6 @@
 <suppressions>
     <!-- <suppress checks="FileLength" -->
               <!-- files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/> -->
+
+    <suppress checks="MissingJavadocType" files=".*doc-examples.*" />
 </suppressions>


### PR DESCRIPTION
Excluding the new checkstyle `MissingJavadocType` from all classes in `doc-examples` directories. Without this we would need to add javadoc to all the classes (at class level) used for the examples. For example the build was failing in GCP module.