### PR TITLE
Use github action setup-graalvm version instead of commit

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Setup GraalVM CE
-        uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+        uses: DeLaGuardo/setup-graalvm@3.0
         with:
           graalvm-version: ${{ matrix.graalvm }}
       - name: Install Native Image


### PR DESCRIPTION
Version `3.0` points the (same commit)[https://github.com/DeLaGuardo/setup-graalvm/commit/8bbfe44ef9c6f5c07e5af036a1bffd561c037d18] that we are already using, but it's better to use the release instead of the version.