### PR TITLE
Add a publishing step back to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ jobs:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to Sonatype OSSRH
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GPG_FILE: ${{ secrets.GPG_FILE }}
+        run: |
+          echo $GPG_FILE | base64 -d > secring.gpg
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       - name: Generate docs
         run: ./gradlew docs
       - name: Export Gradle Properties


### PR DESCRIPTION
It is introduced as early as possible

I am leaving the manual workflow just in case.

Once the new infra proves stable enough, it can be possibly removed.