### PR TITLE
Some minor fixes

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository == 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 3
       matrix:
         repo:
           - acme

--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -44,7 +44,6 @@ jobs:
           - multitenancy
           - nats
           - neo4j
-          - netflix
           - openapi
           - oracle-cloud
           - picocli
@@ -54,7 +53,6 @@ jobs:
           - reactor
           - redis
           - rss
-          - rxjava1
           - rxjava3
           - security
           - servlet

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -17,7 +17,7 @@ jobs:
           echo ::set-output name=latest_version::${latest}
           ./gradlew wrapper --gradle-version $latest
       - uses: gradle/wrapper-validation-action@v1
-      - uses: stefanzweifel/git-auto-commit-action@v4.8.0
+      - uses: stefanzweifel/git-auto-commit-action@v4.9.0
         with:
           commit_message: Upgrade Gradle Wrapper to ${{ steps.update.outputs.latest_version }}
           commit_user_name: micronaut-build

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.0"
+        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.1"
+        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.2"
     }
 }
 


### PR DESCRIPTION
This PR includes:

- Setting the max-parallel jobs to 3 to avoid sending too much PRs to all the modules too fast so Github triggers an abuse mechanism and cancel the remaining jobs.
- Removed `netflix` and `rxjava1` modules and archived the repos because we won't release any new versions.
- Upgrade internal build plugin to 3.0.2
- bump stefanzweifel/git-auto-commit-action from v4.8.0 to v4.9.0