### PR TITLE
Upgrade template to build plugins 5.0.x

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.xxx-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.xxx-base.gradle
@@ -1,0 +1,2 @@
+version = projectVersion
+group = 'io.micronaut.xxx'

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.xxx-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.xxx-module.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'io.micronaut.build.internal.xxx-base'
+    id "io.micronaut.build.internal.module"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,9 +6,10 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '4.2.3'
+    id 'io.micronaut.build.shared.settings' version '5.0.1'
 }
 
 rootProject.name = 'xxx-parent'
 
 include 'xxx'
+include 'xxx-bom'

--- a/xxx-bom/build.gradle
+++ b/xxx-bom/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'io.micronaut.build.internal.xxx-base'
+    id "io.micronaut.build.internal.bom"
+}

--- a/xxx/build.gradle
+++ b/xxx/build.gradle
@@ -1,5 +1,3 @@
 plugins {
-    id "io.micronaut.build.internal.module"
+    id 'io.micronaut.build.internal.xxx-module'
 }
-
-group = 'io.micronaut.xxx'


### PR DESCRIPTION
This also updates the template to show how to use `buildSrc` to define a convention plugin and a BOM module.