### PR TITLE
Add entry to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 .gradle/
 .idea/
 build/
+!build-logic/src/main/java/io/micronaut/build
 classes/
 out/
 *.db


### PR DESCRIPTION
This entry is here for projects which use `build-logic` as an
alternative to `buildSrc` (which is the case for Micronaut AOT and
will become the preferred way in the future, as defined by idiomatic
Gradle rules).

The `build/` ignore is too wide, so this commit adds an entry to
make sure sources are not excluded.