### PR TITLE
Remote --delete option from rsync

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Sync workflows
         run: |
           mkdir -p target/.github/workflows/
-          rsync --verbose --verbose  --delete --archive -F "source/.github/workflows/" "target/.github/workflows/"
+          rsync --verbose --verbose  --archive -F "source/.github/workflows/" "target/.github/workflows/"
       - name: Copy files from source to target branches
         run: |
           while IFS= read -r file; do


### PR DESCRIPTION
The current config removes any additional non-standard workflows in a project. For example for `micronaut-test` it deleted the native testing workflow https://github.com/micronaut-projects/micronaut-test/commit/331fb0616d54ccc5ffeb50e8092ed84d29c8c6be#diff-35770d9927e261c42b335497465a68e6d416bda0899941cb4940b4e07d2ae174

I don't think we should be deleting additional workflows