### PR TITLE
Allow having a custom, optional suppressions config file.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -82,6 +82,10 @@
         <property name="file" value="${config_loc}/suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/custom-suppressions.xml"/>
+        <property name="optional" value="true"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/>


### PR DESCRIPTION
Since `suppressions.xml` is managed by the sync process, projects having custom suppressions
always have conflicts when the sync process runs.

This change allows an additional an optional `custom-suppressions.xml` that projects can use
for adding local suppression rules. The existing `suppressions.xml` can be left managed to
include global suppression rules should we want it.