### PR TITLE
Allow retries in action-junit-report to not fail on flaky tests

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -60,3 +60,4 @@ jobs:
         with:
           check_name: GraalVM CE CI / Test Report (Java ${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_retries: 'true'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_retries: 'true'
       - name: Publish to Sonatype Snapshots
         if: success() && github.event_name == 'push' && matrix.java == '8'
         env:


### PR DESCRIPTION
We added flaky test support to the action, so when a test passes after a retry, it's still considered a success.

But I forgot to enable it here 😔