### PR TITLE
Fix micronaut-core docs publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           BRANCH: gh-pages
           FOLDER: build/docs
           VERSION: ${{ steps.release_version.outputs.release_version }}
+          TARGET_REPOSITORY: ${{ github.repository == 'micronaut-projects/micronaut-core' && env.docsRepository || github.repository }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}


### PR DESCRIPTION
This PR allows the release workflow to work for both micronaut-core and all the other repos.

In the case of core, the docs must be published in the GitHub Pages of micronaut-docs. This is defined in the [`docsRepository`](https://github.com/micronaut-projects/micronaut-core/blob/3.4.x/gradle.properties#L6) variable in core. For the other repos, they just publish docs to their own GitHub Pages, which is represented by the `github.repository` context property.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/7126