### PR TITLE
Use version catalogs

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -112,7 +112,7 @@ jobs:
             .github/ISSUE_TEMPLATE/config.yml
             .github/ISSUE_TEMPLATE/new_feature.yaml
             .github/ISSUE_TEMPLATE/other.yaml
-            gradle/*
+            gradle/wrapper/*
             gradlew*
             MAINTAINING.md
             SECURITY.md

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           # Awful hack for kapt and JDK 16. See https://youtrack.jetbrains.com/issue/KT-45545
           if [ ${{ matrix.java }} == 16 ]; then export GRADLE_OPTS="-Dorg.gradle.jvmargs=--illegal-access=permit"; fi
-          ./gradlew dependencyUpdates check --no-daemon --parallel --continue
+          ./gradlew check --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
     id "io.micronaut.build.internal.docs"
-    id "io.micronaut.build.internal.dependency-updates"
     id "io.micronaut.build.internal.quality-reporting"
 }

--- a/config/checkstyle/.rsync-filter
+++ b/config/checkstyle/.rsync-filter
@@ -1,2 +1,0 @@
-- suppressions.xml
-- checkstyle.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,5 @@
 projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.project-template
-micronautDocsVersion=2.0.0
-micronautVersion=3.4.3
-micronautTestVersion=3.1.1
-groovyVersion=3.0.10
-spockVersion=2.0-groovy-3.0
 
 title=Micronaut project-template
 projectDesc=TODO

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,48 @@
+#
+# This file is used to declare the list of libraries
+# which are used as dependencies in the project.
+# See https://docs.gradle.org/7.4.2/userguide/platforms.html#sub:central-declaration-of-dependencies
+#
+# For Micronaut, we have 3 kinds of dependencies:
+#   - managed dependencies, which are exposed to consumers via a BOM (or version catalog)
+#   - managed BOMs, which are imported into the BOM that we generate
+#   - all other dependencies, which are implementation details
+#
+# If a library needs to appear in the BOM of the project, then it must be
+# declared with the "managed-" prefix.
+# If a BOM needs to be imported in the BOM of the project, then it must be
+# declared with the "boms-" prefix.
+# Both managed dependencies and BOMs need to have their version declared via
+# a managed version (a version which alias starts with "managed-"
+
+[versions]
+micronaut = "3.4.3"
+micronaut-docs = "2.0.0"
+micronaut-test = "3.1.1"
+groovy = "3.0.10"
+spock = "2.1-groovy-3.0"
+
+# Managed versions appear in the BOM
+# managed-somelib = "1.0"
+# managed-somebom = "1.1"
+
+[libraries]
+
+#
+# Managed dependencies appear in the BOM
+#
+# managed-somelib = { module = "group:artifact", version.ref = "managed-somelib" }
+
+#
+# Imported BOMs, also appearing in the generated BOM
+#
+# boms-somebom = { module = "com.foo:somebom", version.ref = "managed-somebom" }
+
+# Other libraries used by the project but non managed
+
+# micronaut-bom = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
+# jdoctor = { module = "me.champeau.jdoctor:jdoctor-core", version.ref="jdoctor" }
+
+[bundles]
+
+[plugins]

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,14 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.3.5'
+    id 'io.micronaut.build.shared.settings' version '5.3.6'
 }
 
 rootProject.name = 'project-template-parent'
 
 include 'project-template'
 include 'project-template-bom'
+
+micronautBuild {
+    importMicronautCatalog()
+}


### PR DESCRIPTION
This commit updates the template so that it makes use of Gradle version catalogs.
This also removes the "dependency updates" plugin as this is no longer used since we moved to renovate.