### PR TITLE
Remove Gradle plugin from sync

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -28,7 +28,6 @@ jobs:
           - email
           - flyway
           - gcp
-          - gradle-plugin
           - graphql
           - groovy
           - grpc


### PR DESCRIPTION
The Gradle plugin has different workflows, in particular because
it publishes to the plugin portal and requires special testing
setup.

Workflow update PRs are more noisy than helpful.