### PR TITLE
Upload binary compatibility check reports

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,6 +65,12 @@ jobs:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_retries: 'true'
+      - name: "📜 Upload binary compatibility check results"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: binary-compatibility-reports
+          path: "**/build/reports/binary-compatibility-*.html"
       - name: Publish to Sonatype Snapshots
         if: success() && github.event_name == 'push' && matrix.java == '11'
         env:

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.3.10'
+    id 'io.micronaut.build.shared.settings' version '5.3.11'
 }
 
 rootProject.name = 'project-template-parent'


### PR DESCRIPTION
So that if a binary check fails, we can see what's wrong.