### PR TITLE
feat(ci): add slsa provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           echo $GPG_FILE | base64 -d > secring.gpg
           # Publish both locally and to Sonatype.
           # The artifacts stored locally will be used to generate the SLSA provenance.
-          ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishAllPublicationsToBuildRepository publishToSonatype closeAndReleaseSonatypeStagingRepository
           # Read the current version from gradle.properties.
           VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
           # Read the project group from gradle.properties.
@@ -59,16 +59,16 @@ jobs:
         id: hash
         run: |
           # Find the relevant published artifacts in the local repository.
-          ARTIFACTS=$(find ~/.m2/repository/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* -regextype sed -regex '.*${{ steps.publish.outputs.version }}\(\.jar\|.*\.pom\)')
+          ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* -regextype sed -regex '\(.*\.jar\|.*\.pom\)')
           # Compute the hashes for the artifacts.
           echo "::set-output name=hashes::$(sha256sum $ARTIFACTS | base64 -w0)"
       - name: Upload build artifacts
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: gradle-build-outputs
-          path: ~/.m2/repository/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
+          path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 5
       - name: Generate docs
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
   release:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }} # Computed hashes for build artifacts.
-      version: ${{ steps.publish.outputs.version }} # Artifact version read from gradle.properties.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -135,17 +134,13 @@ jobs:
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
         with:
           name: gradle-build-outputs
-          path: dist
+          path: build/repo
       - name: Upload assets
-        # Upload the artifacts and SLSA L3 provenance as assets to the existing release.
-        # The artifacts for each module are stored separately in a zip file. Note that
-        # the provenance will attest to the artifact files and not the aggregated zip file.
+        # Upload the artifacts and SLSA L3 provenance as assets to the existing
+        # release. Note that the provenance will attest to each artifact file and
+        # not the aggregated ZIP file.
         run: |
-          ARTIFACTS=""
-          for dir in dist/* ; do
-            zip -j `basename $dir`.zip $dir/${{ needs.release.outputs.version }}/*
-            ARTIFACTS="$ARTIFACTS `basename $dir`.zip"
-          done
-          gh release upload ${{ github.ref_name }} $ARTIFACTS          
+          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\)' | xargs zip artifacts.zip
+          gh release upload ${{ github.ref_name }} artifacts.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,8 @@ jobs:
         id: hash
         run: |
           # Find the relevant published artifacts in the local repository.
-          ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* -regextype sed -regex '\(.*\.jar\|.*\.pom\)')
+          ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
+              -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)')
           # Compute the hashes for the artifacts.
           echo "::set-output name=hashes::$(sha256sum $ARTIFACTS | base64 -w0)"
       - name: Upload build artifacts
@@ -140,7 +141,7 @@ jobs:
         # release. Note that the provenance will attest to each artifact file and
         # not the aggregated ZIP file.
         run: |
-          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\)' | xargs zip artifacts.zip
+          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)' | xargs zip artifacts.zip
           gh release upload ${{ github.ref_name }} artifacts.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     types: [published]
 jobs:
   release:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }} # Computed hashes for build artifacts.
+      version: ${{ steps.publish.outputs.version }} # Artifact version read from gradle.properties.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,6 +34,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Sonatype OSSRH
+        id: publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -42,7 +46,29 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: |
           echo $GPG_FILE | base64 -d > secring.gpg
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          # Publish both locally and to Sonatype.
+          # The artifacts stored locally will be used to generate the SLSA provenance.
+          ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository
+          # Read the current version from gradle.properties.
+          VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
+          # Read the project group from gradle.properties.
+          GROUP_PATH=$(./gradlew properties| grep "projectGroup" | awk '{print $2}' | sed 's/\./\//g')
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=group::$GROUP_PATH"
+      - name: Generate subject
+        id: hash
+        run: |
+          # Find the relevant published artifacts in the local repository.
+          ARTIFACTS=$(find ~/.m2/repository/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* -regextype sed -regex '.*${{ steps.publish.outputs.version }}\(\.jar\|.*\.pom\)')
+          # Compute the hashes for the artifacts.
+          echo "::set-output name=hashes::$(sha256sum $ARTIFACTS | base64 -w0)"
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: gradle-build-outputs
+          path: ~/.m2/repository/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
+          if-no-files-found: error
+          retention-days: 1
       - name: Generate docs
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -86,3 +112,40 @@ jobs:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance:
+    needs: [release]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: true # Upload to a new release
+
+  github_release:
+    needs: [release, provenance]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - name: Download artifacts
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+        with:
+          name: gradle-build-outputs
+          path: dist
+      - name: Upload assets
+        # Upload the artifacts and SLSA L3 provenance as assets to the existing release.
+        # The artifacts for each module are stored separately in a zip file. Note that
+        # the provenance will attest to the artifact files and not the aggregated zip file.
+        run: |
+          ARTIFACTS=""
+          for dir in dist/* ; do
+            zip -j `basename $dir`.zip $dir/${{ needs.release.outputs.version }}/*
+            ARTIFACTS="$ARTIFACTS `basename $dir`.zip"
+          done
+          gh release upload ${{ github.ref_name }} $ARTIFACTS          
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Open Source Security Foundation has been developing a standard for supply chain security called [SLSA](https://slsa.dev) to allow users of open source projects to verify the artifacts and their build pipelines. To make that possible, the release pipelines should generate a [provenance](https://slsa.dev/provenance/v0.2) that provides verifiable information about how the software artifacts are built.

This PR adds a reusable [GitHub Actions workflow](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md) to generate the provenance and publish that together with the artifacts as GitHub release artifacts. This would help users verify that the release artifacts are built from the `release.yml` workflow and not somewhere else. You can read more about this provenance generator [here](http://slsa.dev/blog/2022/08/slsa-github-workflows-generic-ga).

 Looking forward to the feedback and discussions.
