### PR TITLE
fix(ci): build the SLSA provenance generator from source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,8 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true # Upload to a new release
+      upload-assets: true # Upload to a new release.
+      compile-generator: true # Build the generator from source.
 
   github_release:
     needs: [release, provenance]


### PR DESCRIPTION
The `Generate Builder` step in the provenance generation job has [failed](https://github.com/micronaut-projects/micronaut-coherence/actions/runs/3187055825/jobs/5198289749) in `micronaut-coherence` due to a known [issue](https://github.com/slsa-framework/slsa-github-generator/issues/942) related to the public [Rekor](https://github.com/sigstore/rekor) instance, which is the transparency log that the provenance generator binary is recorded on for verification. The Rekor instance had a breaking change and the recommended solution until the Rekor is GA is to build the generator from source to avoid the verification step for the provenance generator.

