### PR TITLE
Filter graphql-java snapshot versions.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,10 @@
     {
       "matchPackagePatterns": ["actions.*"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchPackagePrefixes": ["com.graphql-java:"],
+      "allowedVersions": "/^[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
     }
   ]
 }


### PR DESCRIPTION
Hello!

I'm not sure this is the correct place to put such a config, because `.github/renovate.json` file in micronaut-graphql repository will be overwritten by the bot and use this repo as a source of true, I have no choice but put it here.

This fix will configure renovate bot to look for the correct version for graphql-java modules, as graphql-java uses different versions to deploy snapshots build to Maven Central, for example, these versions aren't final release versions:

1) https://repo1.maven.org/maven2/com/graphql-java/graphql-java/0.0.0-2022-10-18T05-29-18-4024420a/
2) https://repo1.maven.org/maven2/com/graphql-java/graphql-java/2021-05-03T08-53-12-8f1ec444/
3) https://repo1.maven.org/maven2/com/graphql-java/graphql-java/230521-nf-execution/

The release versions use semver pattern:

https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/

This will fix wrong PRs, like these two:

1) https://github.com/micronaut-projects/micronaut-graphql/pull/292
2) https://github.com/micronaut-projects/micronaut-graphql/pull/293