### PR TITLE
Don't override the file if a lock file exists.

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
               dest="$(dirname $file)"
               mkdir -p target/$dest
-              cp -r source/$file target/$dest
+              [ ! -f target/${dest}.lock ] && cp -r source/$file target/$dest
           done <<< "$FILES"
         env:
           FILES: |-


### PR DESCRIPTION
This PR is adding a capability to ignore some files during the sync, which was suggested by @alvarosanchez here: https://github.com/micronaut-projects/micronaut-project-template/pull/279#issuecomment-1293148838