### PR TITLE
Remove SLSA Provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
     types: [published]
 jobs:
   release:
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }} # Computed hashes for build artifacts.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,7 +31,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Sonatype OSSRH
-        id: publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -45,30 +42,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: |
           echo $GPG_FILE | base64 -d > secring.gpg
-          # Publish both locally and to Sonatype.
-          # The artifacts stored locally will be used to generate the SLSA provenance.
-          ./gradlew publishAllPublicationsToBuildRepository publishToSonatype closeAndReleaseSonatypeStagingRepository
-          # Read the current version from gradle.properties.
-          VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
-          # Read the project group from gradle.properties.
-          GROUP_PATH=$(./gradlew properties| grep "projectGroup" | awk '{print $2}' | sed 's/\./\//g')
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=group::$GROUP_PATH"
-      - name: Generate subject
-        id: hash
-        run: |
-          # Find the relevant published artifacts in the local repository.
-          ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
-              -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)')
-          # Compute the hashes for the artifacts.
-          echo "::set-output name=hashes::$(sha256sum $ARTIFACTS | base64 -w0)"
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
-        with:
-          name: gradle-build-outputs
-          path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
-          if-no-files-found: error
-          retention-days: 5
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       - name: Generate docs
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -112,37 +86,3 @@ jobs:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  provenance:
-    needs: [release]
-    permissions:
-      actions: read # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
-    with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true # Upload to a new release.
-      compile-generator: true # Build the generator from source.
-
-  github_release:
-    needs: [release, provenance]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-      - name: Download artifacts
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
-        with:
-          name: gradle-build-outputs
-          path: build/repo
-      - name: Upload assets
-        # Upload the artifacts and SLSA L3 provenance as assets to the existing
-        # release. Note that the provenance will attest to each artifact file and
-        # not the aggregated ZIP file.
-        run: |
-          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)' | xargs zip artifacts.zip
-          gh release upload ${{ github.ref_name }} artifacts.zip
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to an [ongoing issue](https://github.com/orgs/community/discussions/37942), Provenance regularly fails when we are publishing a release.

We will remove it for now.

Revert "feat(ci): add slsa provenance for release artifacts (#263)"

This reverts commit 608ba93861c63309160804d535e8028d3f024c72.

Fixes #286