### PR TITLE
Enable javadoc parsing for UnusedImports checkstyle rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -120,7 +120,7 @@
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports">
-            <property name="processJavadoc" value="false"/>
+            <property name="processJavadoc" value="true"/>
         </module>
 
         <!-- Checks for Size Violations.                    -->


### PR DESCRIPTION
Right now, when you reference a class in javadoc, you have to use the fully qualified name unless the class has already been imported. If you add an import only for the javadoc, checkstyle would complain that the import is unused.

After this change, checkstyle finds uses of the import in the javadoc properly.