### PR TITLE
Remove deprecated save-state and set-output commands

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           branch=$(git rev-parse --abbrev-ref HEAD)
           echo "Current branch: ${branch}"
-          echo ::set-output name=branch::${branch}
+          echo "name=branch::${branch}" >> $GITHUB_OUTPUT
       - name: Sync workflows
         run: |
           mkdir -p target/.github/workflows/

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -21,7 +21,7 @@ jobs:
         id: check_release_drafter
         run: |
           has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo ::set-output name=has_release_drafter::${has_release_drafter}
+          echo "name=has_release_drafter::${has_release_drafter}" >> $GITHUB_OUTPUT
 
       # If it has release drafter:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '17'
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:11}
+        run: echo "release_version::${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -23,7 +23,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: |
           latest=`curl -s https://services.gradle.org/versions/current | jq -cr ".version"`
-          echo ::set-output name=latest_version::${latest}
+          echo "name=latest_version::${latest}" >> $GITHUB_OUTPUT
           ./gradlew wrapper --gradle-version $latest
       - uses: gradle/wrapper-validation-action@v1
       - uses: stefanzweifel/git-auto-commit-action@v4.16.0


### PR DESCRIPTION
save-state and set-output commands have been deprecated and set for removal in June 2023.

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #323