### PR TITLE
fix(ci): address gh cli release upload race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,18 +161,18 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: gradle-build-outputs
           path: build/repo
+      - name: Create artifacts archive
+        shell: bash
+        run: find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)' | xargs zip artifacts.zip
       - name: Upload assets
-        # Upload the artifacts and SLSA L3 provenance as assets to the existing
-        # release. Note that the provenance will attest to each artifact file and
-        # not the aggregated ZIP file.
-        run: |
-          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)' | xargs zip artifacts.zip
-          gh release upload ${{ github.ref_name }} artifacts.zip
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Upload the artifacts to the existing release. Note that the SLSA provenance will
+        # attest to each artifact file and not the aggregated ZIP file.
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          files: artifacts.zip


### PR DESCRIPTION
This PR fixes a race condition I have seen in the [github_release](https://github.com/micronaut-projects/micronaut-project-template/blob/d93498a7f1e87479cde0ec2f4ad9938525c3c279/.github/workflows/release.yml#L176) step. There is a known [issue](https://github.com/cli/cli/issues/6198) in `gh release upload` that sometimes fails to find an existing release using the tag name due to a lag that occurs between creating a release and accessing it by tag name. [This](https://github.com/micronaut-projects/micronaut-test/actions/runs/4384359119/jobs/7675843527#step:4:41) is one example release workflow that has failed due to this issue.

This PR adds [softprops/action-gh-release](https://github.com/softprops/action-gh-release) to upload the artifact, which handles such issues gracefully.