### PR TITLE
Remove parallel from Gradle workflow

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "🛠 Build with Gradle"
         id: gradle
         run: |
-          ./gradlew check --no-daemon --parallel --continue
+          ./gradlew check --no-daemon --continue
 
       - name: "📊 Publish Test Report"
         if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,7 +63,7 @@ jobs:
       - name: "🛠 Build with Gradle"
         id: gradle
         run: |
-          ./gradlew check --no-daemon --parallel --continue
+          ./gradlew check --no-daemon --continue
 
       - name: "🔎 Run static analysis"
         if: env.SONAR_TOKEN != ''


### PR DESCRIPTION
Individual builds can decide whether to execute in parallel by modifying gradle.properties