### PR TITLE
Remove files-sync.yml from other micronaut projects

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -103,6 +103,7 @@ jobs:
           rm -f target/.github/workflows/dependency-update.yml
           rm -f target/.github/workflows/sonarqube.yml
           rm -f target/.github/workflows/graalvm.yml
+          rm -f target/.github/workflows/files-sync.yml
       - name: Copy files from source to target branches
         run: |
           while IFS= read -r file; do


### PR DESCRIPTION
files-sync.yml should exist only in micronaut-project-template, but currently exists in many micronaut projects, so need to be removed.