### PR TITLE
Modified github graalvm workflows to execute native tests in parallel

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -8,13 +8,30 @@ on:
   schedule:
     - cron: "0 1 * * 1-5" # Mon-Fri at 1am UTC
 jobs:
+  build_matrix:
+    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Matrix
+        uses: micronaut-projects/github-actions/graalvm/build-matrix@parallel-native-tests
+        id: build-matrix
+        with:
+          graalvm: 'dev'
+          java: '17'
   build:
+    needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        graalvm: [ 'dev' ]
-        java: [ '17' ]
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -28,11 +45,13 @@ jobs:
           graalvm: ${{ matrix.graalvm }}
           java: ${{ matrix.java }}
       - name: Build Steps
-        uses: micronaut-projects/github-actions/graalvm/build@master
+        uses: micronaut-projects/github-actions/graalvm/build@parallel-native-tests
         id: build
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+        with:
+          nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps
         uses: micronaut-projects/github-actions/graalvm/post-build@master
         id: post-build

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -14,13 +14,30 @@ on:
       - master
       - '[1-9]+.[0-9]+.x'
 jobs:
+  build_matrix:
+    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Matrix
+        uses: micronaut-projects/github-actions/graalvm/build-matrix@parallel-native-tests
+        id: build-matrix
+        with:
+          graalvm: 'latest'
+          java: '17'
   build:
+    needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        graalvm: [ 'latest' ]
-        java: [ '17' ]
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -34,11 +51,13 @@ jobs:
           graalvm: ${{ matrix.graalvm }}
           java: ${{ matrix.java }}
       - name: Build Steps
-        uses: micronaut-projects/github-actions/graalvm/build@master
+        uses: micronaut-projects/github-actions/graalvm/build@parallel-native-tests
         id: build
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+        with:
+          nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps
         uses: micronaut-projects/github-actions/graalvm/post-build@master
         id: post-build


### PR DESCRIPTION
Native tests will be executed by different github runners. The maximum number of github runners is set to 6 but we can change that if necessary.
**IMPORTANT:** Modified graalvm workflows will be using two github actions (build-matrix and build) from [parallel-native-tests](https://github.com/micronaut-projects/github-actions/compare/master...parallel-native-tests) branch until these workflow changes get applied to all micronaut projects since we don't want to break builds for projects which haven't applied workflow changes. Once all projects apply workflow changes, we can push github action changes from `parallel-native-tests` to `master` branch and update workflows to use all master github actions.