### PR TITLE
Modified github workflows to support the latest GraalVM version

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -20,11 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Matrix
-        uses: micronaut-projects/github-actions/graalvm/build-matrix@master
+        uses: micronaut-projects/github-actions/graalvm/build-matrix@latest-graalvm-changes
         id: build-matrix
-        with:
-          graalvm: 'dev'
-          java: '17'
   build:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
@@ -39,11 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Pre-Build Steps
-        uses: micronaut-projects/github-actions/graalvm/pre-build@master
+        uses: micronaut-projects/github-actions/graalvm/pre-build@latest-graalvm-changes
         id: pre-build
         with:
-          graalvm: ${{ matrix.graalvm }}
-          java: ${{ matrix.java }}
+          java: '17'
       - name: Build Steps
         uses: micronaut-projects/github-actions/graalvm/build@master
         id: build
@@ -56,4 +52,4 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/post-build@master
         id: post-build
         with:
-          java: ${{ matrix.java }}
+          java: '17'

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GRAALVM_QUICK_BUILD: true
         with:
           nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -26,11 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Matrix
-        uses: micronaut-projects/github-actions/graalvm/build-matrix@master
+        uses: micronaut-projects/github-actions/graalvm/build-matrix@latest-graalvm-changes
         id: build-matrix
-        with:
-          graalvm: 'latest'
-          java: '17'
   build:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
@@ -45,11 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Pre-Build Steps
-        uses: micronaut-projects/github-actions/graalvm/pre-build@master
+        uses: micronaut-projects/github-actions/graalvm/pre-build@latest-graalvm-changes
         id: pre-build
         with:
-          graalvm: ${{ matrix.graalvm }}
-          java: ${{ matrix.java }}
+          distribution: 'graalvm-community'
+          java: '17'
       - name: Build Steps
         uses: micronaut-projects/github-actions/graalvm/build@master
         id: build
@@ -62,4 +59,4 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/post-build@master
         id: post-build
         with:
-          java: ${{ matrix.java }}
+          java: '17'

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GRAALVM_QUICK_BUILD: true
         with:
           nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        graalvm: [ 'latest']
+        distribution: [ 'graalvm-community']
         java: ['17']
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -48,7 +48,7 @@ jobs:
       - name: "🔧 Setup GraalVM CE"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: ${{ matrix.graalvm }}
+          distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The graalvm workflows `dev` and `latest` are using `build-matrix` and `pre-build` github composite actions from the [latest-graalvm-changes](https://github.com/micronaut-projects/github-actions/compare/master...latest-graalvm-changes) branch instead of `master` since we don't want to modify github actions in the master until template changes get synched to all micronaut projects.