### PR TITLE
define gradle-build-action version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,7 +52,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "🔧 Setup Gradle"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.9.0
 
       - name: "❓ Optional setup step"
         run: |


### PR DESCRIPTION
There is a dependabot vulnerability alert for versions < 2.4.2

This PRs pins to a specific version of the Gradle build-action. 

Using a specific version instead of @v2 keeps CI more stable. 

see: https://github.com/marketplace/actions/gradle-build-action