### PR TITLE
upload binary compatibility only if java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -77,7 +77,7 @@ jobs:
           check_retries: 'true'
 
       - name: "📜 Upload binary compatibility check results"
-        if: always()
+        if: matrix.java == '17'
         uses: actions/upload-artifact@v4.0.0
         with:
           name: binary-compatibility-reports


### PR DESCRIPTION
https://github.com/actions/upload-artifact#breaking-changes

> Uploading to the same named Artifact multiple times.

> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.