### PR TITLE
chore(deps-dev): use same versions for artifact upload and download Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "📜 Upload binary compatibility check results"
         if: matrix.java == '17'
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: binary-compatibility-reports
           path: "**/build/reports/binary-compatibility-*.html"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,13 @@ jobs:
           # Store the hash in a file, which is uploaded as a workflow artifact.
           sha256sum $ARTIFACTS | base64 -w0 > artifacts-sha256
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3
         with:
           name: gradle-build-outputs
           path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
           retention-days: 5
       - name: Upload artifacts-sha256
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts-sha256
           path: artifacts-sha256
@@ -148,6 +148,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download artifacts
+        # Important: update actions/download-artifact to v4 only when generator_generic_slsa3.yml is also compatible.
+        # See https://github.com/slsa-framework/slsa-github-generator/issues/3068
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: gradle-build-outputs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,13 @@ jobs:
           # Store the hash in a file, which is uploaded as a workflow artifact.
           sha256sum $ARTIFACTS | base64 -w0 > artifacts-sha256
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: gradle-build-outputs
           path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
           retention-days: 5
       - name: Upload artifacts-sha256
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts-sha256
           path: artifacts-sha256
@@ -115,7 +115,7 @@ jobs:
       artifacts-sha256: ${{ steps.set-hash.outputs.artifacts-sha256 }}
     steps:
       - name: Download artifacts-sha256
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifacts-sha256
       # The SLSA provenance generator expects the hash digest of artifacts to be passed as a job


### PR DESCRIPTION
@sdelamo Looks like the provenance action [`generator_generic_slsa3.yml`](https://github.com/micronaut-projects/micronaut-project-template/blob/e5bc687429c0f7ce2bf4aa31e8db12ae6a5f46bd/.github/workflows/release.yml#L137) is not compatible with `actions/download-artifact@v4` yet. We need to make sure these two Actions and `actions/upload-artifact` are all compatible.

This PR reverts `actions/download-artifact` to v3 for now until the next version of `generator_generic_slsa3.yml` that will be compatible with `actions/download-artifact@v4` is released. See this relevant [issue](https://github.com/slsa-framework/slsa-github-generator/issues/3068).