### PR TITLE
Fix matrix for jobs using Oracle GraalVM EA builds.

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -29,12 +29,14 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        java: ['dev']
-        distribution: ['graalvm-community']
+        java: ['dev', '22-ea']
+        distribution: ['graalvm-community', 'graalvm']
         native_test_task: ${{ fromJson(needs.build_matrix.outputs.matrix).native_test_task }}
-        include:
-          - java: '22-ea'
+        exclude:
+          - java: 'dev'
             distribution: 'graalvm'
+          - java: '22-ea'
+            distribution: 'graalvm-community'
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -29,13 +29,13 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        java: ['dev', '22-ea']
+        java: ['dev', 'latest-ea']
         distribution: ['graalvm-community', 'graalvm']
         native_test_task: ${{ fromJson(needs.build_matrix.outputs.matrix).native_test_task }}
         exclude:
           - java: 'dev'
             distribution: 'graalvm'
-          - java: '22-ea'
+          - java: 'latest-ea'
             distribution: 'graalvm-community'
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
This is following up on #448 and fixes the build matrix. I was expecting the dynamically generated matrix to just work for include jobs, but that does not seem to be the case. Instead, I've added the 22-ea build to the matrix, and excluded invalid combinations. I verified this is working correctly [here](https://github.com/fniephaus/micronaut-core/actions/runs/7962190223).

Note this depends on https://github.com/micronaut-projects/github-actions/pull/40.