### PR TITLE
chore(deps): update SLSA provenance generator Action to v1.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: "${{ needs.provenance-subject.outputs.artifacts-sha256 }}"
       upload-assets: true # Upload to a new release.


### PR DESCRIPTION
This PR updates SLSA provenance generator Action to `v1.10.0`, which updates a deprecated dependency. This deprecated dependency has caused provenance generation in `v1.9.0` to fail.

Related issue which is now fixed in this release: https://github.com/slsa-framework/slsa-github-generator/issues/3350