### PR TITLE
Activate Automerge for Renovate for Patch Releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,14 @@
     {
       "matchPackagePatterns": ["actions.*"],
       "dependencyDashboardApproval": true
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
As discussed in https://github.com/micronaut-projects/micronaut-project-template/issues/349

I think the benefits out weigh the downsides. We can start with just patch releases for the moment.