### PR TITLE
Install both Java 21 and Java 17 in release workflows

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: |
+            17
+            21
       - name: Publish to Sonatype OSSRH
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: |
+            17
+            21
       - name: Publish to Sonatype Snapshots
         if: success()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: |
+            17
+            21
       - name: Set the current release version
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This commit changes the release workflows so that the use Java 21 for publishing. This will _not_ change the default version of Micronaut project to 17, this is only installing Java 21, so that we can release modules which depend on Java 21, such as `micronaut-langchain4j-jllama`.

In such a case, currently it's possible to configure a module to build with 21, but it would never be released, because our release workflows depend on 17. With this change, the module will now be released with 21. For modules which are using the defaults, the Java 17 toolchain is going to be used.

Should fix https://github.com/micronaut-projects/micronaut-langchain4j/issues/171 once the template is sync'ed.