### PR TITLE
Use Maven Central Publisher API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           echo $GPG_FILE | base64 -d > secring.gpg
           # Publish both locally and to Sonatype.
           # The artifacts stored locally will be used to generate the SLSA provenance.
-          ./gradlew publishAllPublicationsToBuildRepository publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToMavenCentral --publishing-type=AUTOMATIC
           # Read the current version from gradle.properties.
           VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
           # Read the project group from gradle.properties.

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
 plugins {
-    id "io.micronaut.build.internal.docs"
-    id "io.micronaut.build.internal.quality-reporting"
+    id "io.micronaut.build.internal.parent"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.5.0'
+    id 'io.micronaut.build.shared.settings' version '7.6.4'
 }
 
 rootProject.name = 'project-template-parent'


### PR DESCRIPTION
This commit updates the template to use the new publishing task, which makes use of the Publisher API. This API is more reliable than the old one since Maven Central changed their backend.

However, this requires that projects update their root project's build script to use the new "parent" plugin, as seen in this PR.

In other words, publishing will fail if that plugin is not applied.

In addition, this reverts Gradle to 8.14.x, since our builds are NOT ready for Gradle 9 (in particular any project which uses a Kotlin 1.9 plugin will FAIL).

Note for reviewers: I have successfully released Test Resources 2.10.1 using this new process.