### PR TITLE
fix: checkout using github.sha in github_release to avoid tag-moved error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Add `ref: ${{ github.sha }}` to the `github_release` checkout so it uses the triggering commit SHA directly instead of resolving the tag.
  
@alvarosanchez this pr aims to fix the failures such as:

https://github.com/micronaut-projects/micronaut-platform/actions/runs/24021855059/job/70053097130