### PR TITLE
remove env in GitHub Actions before jobs

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -13,16 +13,14 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-env:
-  ALLOW_SECRETS: ${{ github.event.pull_request == null && 'true' || '' }}
 jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
-      DEVELOCITY_CACHE_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
-      DEVELOCITY_CACHE_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+      DEVELOCITY_ACCESS_KEY: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+      DEVELOCITY_CACHE_USERNAME: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -42,9 +40,9 @@ jobs:
         java: ['25']
         native_test_task: ${{ fromJson(needs.build_matrix.outputs.matrix).native_test_task }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
-      DEVELOCITY_CACHE_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
-      DEVELOCITY_CACHE_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+      DEVELOCITY_ACCESS_KEY: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+      DEVELOCITY_CACHE_USERNAME: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
     steps:
       - name: Remove system JDKs
         run: |
@@ -64,8 +62,8 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: build
         env:
-          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ env.ALLOW_SECRETS && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
-          GH_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GH_USERNAME || '' }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event.pull_request == null && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+          GH_USERNAME: ${{ github.event.pull_request == null && secrets.GH_USERNAME || '' }}
           GRAALVM_QUICK_BUILD: true
         with:
           nativeTestTask: ${{ matrix.native_test_task }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,8 +13,6 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-env:
-  PREDICTIVE_TEST_SELECTION: "${{ github.event.pull_request != null && 'true' || 'false' }}"
 jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,6 @@ on:
       - master
       - '[0-9]+.[0-9]+.x'
 env:
-  ALLOW_SECRETS: ${{ github.event.pull_request == null && 'true' || '' }}
   PREDICTIVE_TEST_SELECTION: "${{ github.event.pull_request != null && 'true' || 'false' }}"
 jobs:
   build:
@@ -24,16 +23,16 @@ jobs:
       matrix:
         java: ['25']
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
-      DEVELOCITY_CACHE_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
-      DEVELOCITY_CACHE_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
-      GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ env.ALLOW_SECRETS && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
-      GH_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GH_USERNAME || '' }}
+      DEVELOCITY_ACCESS_KEY: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+      DEVELOCITY_CACHE_USERNAME: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+      GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event.pull_request == null && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+      GH_USERNAME: ${{ github.event.pull_request == null && secrets.GH_USERNAME || '' }}
       TESTCONTAINERS_RYUK_DISABLED: true
-      SONAR_TOKEN: ${{ env.ALLOW_SECRETS && secrets.SONAR_TOKEN || '' }}
-      GITHUB_TOKEN: ${{ env.ALLOW_SECRETS && github.token || '' }}
-      OSS_INDEX_USERNAME: ${{ env.ALLOW_SECRETS && secrets.OSS_INDEX_USERNAME || '' }}
-      OSS_INDEX_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.OSS_INDEX_PASSWORD || '' }}
+      SONAR_TOKEN: ${{ github.event.pull_request == null && secrets.SONAR_TOKEN || '' }}
+      GITHUB_TOKEN: ${{ github.event.pull_request == null && github.token || '' }}
+      OSS_INDEX_USERNAME: ${{ github.event.pull_request == null && secrets.OSS_INDEX_USERNAME || '' }}
+      OSS_INDEX_PASSWORD: ${{ github.event.pull_request == null && secrets.OSS_INDEX_PASSWORD || '' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -13,8 +13,6 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-env:
-  PREDICTIVE_TEST_SELECTION: "${{ github.event.pull_request != null && 'true' || 'false' }}"
 jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -14,7 +14,6 @@ on:
       - master
       - '[0-9]+.[0-9]+.x'
 env:
-  ALLOW_SECRETS: ${{ github.event.pull_request == null && 'true' || '' }}
   PREDICTIVE_TEST_SELECTION: "${{ github.event.pull_request != null && 'true' || 'false' }}"
 jobs:
   build:
@@ -24,16 +23,16 @@ jobs:
       matrix:
         java: ['25']
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
-      DEVELOCITY_CACHE_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
-      DEVELOCITY_CACHE_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
-      GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ env.ALLOW_SECRETS && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
-      GH_USERNAME: ${{ env.ALLOW_SECRETS && secrets.GH_USERNAME || '' }}
+      DEVELOCITY_ACCESS_KEY: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+      DEVELOCITY_CACHE_USERNAME: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+      GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event.pull_request == null && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+      GH_USERNAME: ${{ github.event.pull_request == null && secrets.GH_USERNAME || '' }}
       TESTCONTAINERS_RYUK_DISABLED: true
-      SONAR_TOKEN: ${{ env.ALLOW_SECRETS && secrets.SONAR_TOKEN || '' }}
-      GITHUB_TOKEN: ${{ env.ALLOW_SECRETS && github.token || '' }}
-      OSS_INDEX_USERNAME: ${{ env.ALLOW_SECRETS && secrets.OSS_INDEX_USERNAME || '' }}
-      OSS_INDEX_PASSWORD: ${{ env.ALLOW_SECRETS && secrets.OSS_INDEX_PASSWORD || '' }}
+      SONAR_TOKEN: ${{ github.event.pull_request == null && secrets.SONAR_TOKEN || '' }}
+      GITHUB_TOKEN: ${{ github.event.pull_request == null && github.token || '' }}
+      OSS_INDEX_USERNAME: ${{ github.event.pull_request == null && secrets.OSS_INDEX_USERNAME || '' }}
+      OSS_INDEX_PASSWORD: ${{ github.event.pull_request == null && secrets.OSS_INDEX_PASSWORD || '' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs
@@ -75,7 +74,7 @@ jobs:
         id: sonatypescan
         run: |
           ./gradlew ossIndexAudit --no-parallel --info
-                
+
       - name: "❓ Optional cleanup step"
         run: |
           [ -f ./cleanup.sh ] && ./cleanup.sh || [ ! -f ./cleanup.sh ]


### PR DESCRIPTION
Attempt to fix the errors introduced by #669 

https://github.com/micronaut-projects/micronaut-object-storage/actions/runs/24132976719/workflow

```
(Line: 27, Col: 30): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '', (Line: 28, Col: 34): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '', (Line: 29, Col: 34): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '', (Line: 30, Col: 39): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '', (Line: 31, Col: 20): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.GH_USERNAME || '', (Line: 33, Col: 20): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.SONAR_TOKEN || '', (Line: 34, Col: 21): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && github.token || '', (Line: 35, Col: 27): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.OSS_INDEX_USERNAME || '', (Line: 36, Col: 27): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ALLOW_SECRETS && secrets.OSS_INDEX_PASSWORD || ''
```