### PR TITLE
Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   central-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -11,6 +11,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -26,6 +28,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -17,6 +17,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       DEVELOCITY_ACCESS_KEY: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
       DEVELOCITY_CACHE_USERNAME: ${{ github.event.pull_request == null && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
@@ -34,6 +36,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: ['25']

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         java: ['25']


### PR DESCRIPTION
## Summary
- add explicit job-level `permissions` to the synced workflows that currently inherit repository defaults
- keep read-only jobs on `contents: read`
- grant `checks: write` only on the Gradle and GraalVM build jobs that publish JUnit check runs

## Verification
- `git diff --check`
- `python3` YAML parse on the six edited workflow files

## Related
- Fixes #673
