### PR TITLE
Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   central-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -11,6 +11,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -26,6 +28,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -17,6 +17,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -34,6 +36,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: ['25']

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         java: ['25']


### PR DESCRIPTION
## Summary
- add explicit `permissions` to the template-synced workflows that currently inherit the repository default token scope
- keep read-only jobs on `contents: read`
- grant `checks: write` only on the Gradle and GraalVM jobs that publish JUnit check runs via shared workflow actions

## Related
- Fixes #673
