### PR TITLE
Manage shared CONTRIBUTING content during file sync

### DIFF
--- a/.github/workflows/contributing-sync-validation.yml
+++ b/.github/workflows/contributing-sync-validation.yml
@@ -1,0 +1,34 @@
+name: Contributing Sync Validation
+
+on:
+  push:
+    paths:
+      - "GLOBAL_CONTRIBUTING.md"
+      - ".github/workflows/files-sync.yml"
+      - ".github/workflows/contributing-sync-validation.yml"
+      - "test-scripts/test_global_contributing_sync.py"
+  pull_request:
+    paths:
+      - "GLOBAL_CONTRIBUTING.md"
+      - ".github/workflows/files-sync.yml"
+      - ".github/workflows/contributing-sync-validation.yml"
+      - "test-scripts/test_global_contributing_sync.py"
+
+jobs:
+  validate-contributing-sync:
+    if: github.repository == 'micronaut-projects/micronaut-project-template'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test global CONTRIBUTING sync logic
+        run: python3 test-scripts/test_global_contributing_sync.py
+
+      - name: Lint shared markdown content
+        run: npx --yes markdownlint-cli2 GLOBAL_CONTRIBUTING.md

--- a/.github/workflows/contributing-sync-validation.yml
+++ b/.github/workflows/contributing-sync-validation.yml
@@ -30,5 +30,10 @@ jobs:
       - name: Test global CONTRIBUTING sync logic
         run: python3 test-scripts/test_global_contributing_sync.py
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
       - name: Lint shared markdown content
-        run: npx --yes markdownlint-cli2 GLOBAL_CONTRIBUTING.md
+        run: npx --yes markdownlint-cli2@0.22.0 GLOBAL_CONTRIBUTING.md

--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -139,6 +139,7 @@ jobs:
             gradle/wrapper/gradle-wrapper.properties
             gradlew
             gradlew.bat
+            CONTRIBUTING.md
             MAINTAINING.md
             SECURITY.md
             LICENSE
@@ -158,6 +159,48 @@ jobs:
           fi
           mkdir -p target/.agents/skills
           rsync "${rsync_args[@]}" source/.agents/skills/ target/.agents/skills/
+      - name: Sync global CONTRIBUTING section
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          source_root = Path('source')
+          target_root = Path('target')
+          target_file = target_root / 'CONTRIBUTING.md'
+          global_file = source_root / 'GLOBAL_CONTRIBUTING.md'
+          start_marker = '<!-- BEGIN MICRONAUT GLOBAL CONTRIBUTING: Managed by micronaut-project-template/GLOBAL_CONTRIBUTING.md. Do not add or modify content below this marker in this file; your changes will be replaced by the sync workflow. -->'
+          end_marker = '<!-- END MICRONAUT GLOBAL CONTRIBUTING -->'
+          newline = chr(10)
+
+          managed_block = global_file.read_text()
+          if not managed_block.endswith(newline):
+              managed_block += newline
+
+          if target_file.exists():
+              target_text = target_file.read_text()
+          else:
+              target_text = ''
+
+          start_index = target_text.find(start_marker)
+          end_index = target_text.find(end_marker)
+
+          if start_index != -1 and end_index != -1 and end_index >= start_index:
+              end_index += len(end_marker)
+              if end_index < len(target_text) and target_text[end_index:end_index + 1] == newline:
+                  end_index += 1
+              updated = target_text[:start_index].rstrip() + newline + newline + managed_block
+          else:
+              prefix = target_text.rstrip()
+              if prefix:
+                  updated = prefix + newline + newline + managed_block
+              else:
+                  updated = managed_block
+
+          if not updated.endswith(newline):
+              updated += newline
+
+          target_file.write_text(updated)
+          PY
       - name: Sleep for 3 minutes to avoid rate limiting
         run: sleep 180s
         shell: bash
@@ -186,6 +229,7 @@ jobs:
             .sdkmanrc
             gradle/*
             gradlew*
+            CONTRIBUTING.md
             MAINTAINING.md
             SECURITY.md
             LICENSE

--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -188,6 +188,7 @@ jobs:
             .sdkmanrc
             gradle/*
             gradlew*
+            CONTRIBUTING.md
             MAINTAINING.md
             SECURITY.md
             LICENSE

--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -139,7 +139,6 @@ jobs:
             gradle/wrapper/gradle-wrapper.properties
             gradlew
             gradlew.bat
-            CONTRIBUTING.md
             MAINTAINING.md
             SECURITY.md
             LICENSE
@@ -160,47 +159,7 @@ jobs:
           mkdir -p target/.agents/skills
           rsync "${rsync_args[@]}" source/.agents/skills/ target/.agents/skills/
       - name: Sync global CONTRIBUTING section
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          source_root = Path('source')
-          target_root = Path('target')
-          target_file = target_root / 'CONTRIBUTING.md'
-          global_file = source_root / 'GLOBAL_CONTRIBUTING.md'
-          start_marker = '<!-- BEGIN MICRONAUT GLOBAL CONTRIBUTING: Managed by micronaut-project-template/GLOBAL_CONTRIBUTING.md. Do not add or modify content below this marker in this file; your changes will be replaced by the sync workflow. -->'
-          end_marker = '<!-- END MICRONAUT GLOBAL CONTRIBUTING -->'
-          newline = chr(10)
-
-          managed_block = global_file.read_text()
-          if not managed_block.endswith(newline):
-              managed_block += newline
-
-          if target_file.exists():
-              target_text = target_file.read_text()
-          else:
-              target_text = ''
-
-          start_index = target_text.find(start_marker)
-          end_index = target_text.find(end_marker)
-
-          if start_index != -1 and end_index != -1 and end_index >= start_index:
-              end_index += len(end_marker)
-              if end_index < len(target_text) and target_text[end_index:end_index + 1] == newline:
-                  end_index += 1
-              updated = target_text[:start_index].rstrip() + newline + newline + managed_block
-          else:
-              prefix = target_text.rstrip()
-              if prefix:
-                  updated = prefix + newline + newline + managed_block
-              else:
-                  updated = managed_block
-
-          if not updated.endswith(newline):
-              updated += newline
-
-          target_file.write_text(updated)
-          PY
+        run: python3 test-scripts/test_global_contributing_sync.py --source-root source --target-root target --write
       - name: Sleep for 3 minutes to avoid rate limiting
         run: sleep 180s
         shell: bash
@@ -229,7 +188,6 @@ jobs:
             .sdkmanrc
             gradle/*
             gradlew*
-            CONTRIBUTING.md
             MAINTAINING.md
             SECURITY.md
             LICENSE

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "MD013": false,
+    "MD041": false
+  }
+}

--- a/GLOBAL_CONTRIBUTING.md
+++ b/GLOBAL_CONTRIBUTING.md
@@ -5,18 +5,16 @@ This section is maintained centrally in `micronaut-project-template` and synced 
 
 Do not add repository-specific changes below the begin marker above. Add local contribution guidance before that marker instead.
 
-### Pull Request Expectations
+### Model Used (Required)
 
-- Include tests for behavioral changes.
-- Include documentation updates when user-facing behavior changes.
-- Link the pull request to the relevant issue when applicable.
-- Make sure CI is green before requesting review.
+Every PR must include a **Model Used** section specifying which AI model produced or assisted with the change. Include the provider, exact model ID/version, context window size, and any relevant capability details (e.g., reasoning mode, tool use). If no AI was used, write "None — human-authored". This applies to all contributors — human and AI alike.
 
-### Code Style
+### CI Must Pass
 
-Micronaut projects use Checkstyle and related build checks to keep code style consistent. Run the relevant Gradle verification tasks locally before opening a pull request.
+All tests must pass before a PR can be merged. Run them locally first and verify CI is green after pushing.
 
-### Branching and Release Awareness
+### Copilot Review
 
-When preparing or reviewing a change, make sure it targets the correct branch for the type of change being made so that patch, minor, and major releases stay aligned.
+We use [GitHub Copilot](https://docs.github.com/en/copilot/concepts/agents/code-review) for automated code review. Your PR must have **all Copilot comments addressed** before it can be merged. If Copilot leaves comments, fix or respond to each one and request a re-review.
+
 <!-- END MICRONAUT GLOBAL CONTRIBUTING -->

--- a/GLOBAL_CONTRIBUTING.md
+++ b/GLOBAL_CONTRIBUTING.md
@@ -1,0 +1,22 @@
+<!-- BEGIN MICRONAUT GLOBAL CONTRIBUTING: Managed by micronaut-project-template/GLOBAL_CONTRIBUTING.md. Do not add or modify content below this marker in this file; your changes will be replaced by the sync workflow. -->
+## Shared Micronaut Contribution Guidance
+
+This section is maintained centrally in `micronaut-project-template` and synced into repository `CONTRIBUTING.md` files.
+
+Do not add repository-specific changes below the begin marker above. Add local contribution guidance before that marker instead.
+
+### Pull Request Expectations
+
+- Include tests for behavioral changes.
+- Include documentation updates when user-facing behavior changes.
+- Link the pull request to the relevant issue when applicable.
+- Make sure CI is green before requesting review.
+
+### Code Style
+
+Micronaut projects use Checkstyle and related build checks to keep code style consistent. Run the relevant Gradle verification tasks locally before opening a pull request.
+
+### Branching and Release Awareness
+
+When preparing or reviewing a change, make sure it targets the correct branch for the type of change being made so that patch, minor, and major releases stay aligned.
+<!-- END MICRONAUT GLOBAL CONTRIBUTING -->

--- a/test-scripts/test_global_contributing_sync.py
+++ b/test-scripts/test_global_contributing_sync.py
@@ -1,8 +1,19 @@
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 START_MARKER = "<!-- BEGIN MICRONAUT GLOBAL CONTRIBUTING: Managed by micronaut-project-template/GLOBAL_CONTRIBUTING.md. Do not add or modify content below this marker in this file; your changes will be replaced by the sync workflow. -->"
 END_MARKER = "<!-- END MICRONAUT GLOBAL CONTRIBUTING -->"
 NEWLINE = chr(10)
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    _ = parser.add_argument('--source-root', type=Path)
+    _ = parser.add_argument('--target-root', type=Path)
+    _ = parser.add_argument('--write', action='store_true')
+    return parser
 
 
 def sync_global_contributing(target_text: str, managed_block: str) -> str:
@@ -10,12 +21,8 @@ def sync_global_contributing(target_text: str, managed_block: str) -> str:
         managed_block += NEWLINE
 
     start_index = target_text.find(START_MARKER)
-    end_index = target_text.find(END_MARKER)
 
-    if start_index != -1 and end_index != -1 and end_index >= start_index:
-        end_index += len(END_MARKER)
-        if end_index < len(target_text) and target_text[end_index:end_index + 1] == NEWLINE:
-            end_index += 1
+    if start_index != -1:
         updated = target_text[:start_index].rstrip() + NEWLINE + NEWLINE + managed_block
     else:
         prefix = target_text.rstrip()
@@ -30,8 +37,24 @@ def sync_global_contributing(target_text: str, managed_block: str) -> str:
     return updated
 
 
+def managed_block_text(source_root: Path) -> str:
+    return (source_root / 'GLOBAL_CONTRIBUTING.md').read_text()
+
+
+def sync_file(source_root: Path, target_root: Path) -> None:
+    target_file = target_root / 'CONTRIBUTING.md'
+    lock_file = target_root / 'CONTRIBUTING.md.lock'
+    if lock_file.exists():
+        return
+
+    managed_block = managed_block_text(source_root)
+    target_text = target_file.read_text() if target_file.exists() else ''
+    updated = sync_global_contributing(target_text, managed_block)
+    _ = target_file.write_text(updated)
+
+
 def test_append_when_marker_is_absent() -> None:
-    managed_block = Path('GLOBAL_CONTRIBUTING.md').read_text()
+    managed_block = managed_block_text(REPO_ROOT)
     original = '# Local repo guide\n\nRepo-specific instructions.\n'
 
     updated = sync_global_contributing(original, managed_block)
@@ -43,26 +66,84 @@ def test_append_when_marker_is_absent() -> None:
     assert updated.rstrip().endswith(managed_block.rstrip())
 
 
+# Existing start marker should replace the managed section and anything after it.
 def test_replace_existing_managed_block() -> None:
-    managed_block = Path('GLOBAL_CONTRIBUTING.md').read_text()
+    managed_block = managed_block_text(REPO_ROOT)
     original = (
         '# Local repo guide\n\nKeep this above.\n\n'
         + START_MARKER
         + '\nOld managed text that should disappear.\n'
         + END_MARKER
         + '\n'
+        + 'Trailing local content that should also disappear.\n'
     )
 
     updated = sync_global_contributing(original, managed_block)
 
     assert updated.startswith('# Local repo guide\n\nKeep this above.\n\n')
     assert 'Old managed text that should disappear.' not in updated
+    assert 'Trailing local content that should also disappear.' not in updated
     assert updated.count(START_MARKER) == 1
     assert updated.count(END_MARKER) == 1
     assert updated.rstrip().endswith(managed_block.rstrip())
 
 
-if __name__ == '__main__':
+# A broken block without the end marker should still be replaced without duplication.
+def test_no_duplicate_block_when_end_marker_is_missing() -> None:
+    managed_block = managed_block_text(REPO_ROOT)
+    original = (
+        '# Local repo guide\n\nKeep this above.\n\n'
+        + START_MARKER
+        + '\nBroken managed text without an end marker.\n'
+    )
+
+    updated = sync_global_contributing(original, managed_block)
+
+    assert 'Broken managed text without an end marker.' not in updated
+    assert updated.count(START_MARKER) == 1
+    assert updated.count(END_MARKER) == 1
+    assert updated.rstrip().endswith(managed_block.rstrip())
+
+
+def test_lock_file_skips_sync(tmp_path: Path) -> None:
+    source_root = REPO_ROOT
+    target_root = tmp_path
+    target_file = target_root / 'CONTRIBUTING.md'
+    lock_file = target_root / 'CONTRIBUTING.md.lock'
+
+    _ = target_file.write_text('# Local repo guide\n')
+    _ = lock_file.write_text('locked\n')
+
+    sync_file(source_root, target_root)
+
+    assert target_file.read_text() == '# Local repo guide\n'
+
+
+def run_tests() -> None:
     test_append_when_marker_is_absent()
     test_replace_existing_managed_block()
+    test_no_duplicate_block_when_end_marker_is_missing()
+
+    with TemporaryDirectory() as tmp_dir:
+        test_lock_file_skips_sync(Path(tmp_dir))
+
+
+def main() -> None:
+    parser = build_parser()
+    args: Namespace = parser.parse_args()
+    source_root = getattr(args, 'source_root', None)
+    target_root = getattr(args, 'target_root', None)
+    write = bool(getattr(args, 'write', False))
+
+    if write:
+        if not isinstance(source_root, Path) or not isinstance(target_root, Path):
+            raise SystemExit('--write requires --source-root and --target-root')
+        sync_file(source_root.resolve(), target_root.resolve())
+        return
+
+    run_tests()
     print('Global CONTRIBUTING sync tests passed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/test-scripts/test_global_contributing_sync.py
+++ b/test-scripts/test_global_contributing_sync.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+START_MARKER = "<!-- BEGIN MICRONAUT GLOBAL CONTRIBUTING: Managed by micronaut-project-template/GLOBAL_CONTRIBUTING.md. Do not add or modify content below this marker in this file; your changes will be replaced by the sync workflow. -->"
+END_MARKER = "<!-- END MICRONAUT GLOBAL CONTRIBUTING -->"
+NEWLINE = chr(10)
+
+
+def sync_global_contributing(target_text: str, managed_block: str) -> str:
+    if not managed_block.endswith(NEWLINE):
+        managed_block += NEWLINE
+
+    start_index = target_text.find(START_MARKER)
+    end_index = target_text.find(END_MARKER)
+
+    if start_index != -1 and end_index != -1 and end_index >= start_index:
+        end_index += len(END_MARKER)
+        if end_index < len(target_text) and target_text[end_index:end_index + 1] == NEWLINE:
+            end_index += 1
+        updated = target_text[:start_index].rstrip() + NEWLINE + NEWLINE + managed_block
+    else:
+        prefix = target_text.rstrip()
+        if prefix:
+            updated = prefix + NEWLINE + NEWLINE + managed_block
+        else:
+            updated = managed_block
+
+    if not updated.endswith(NEWLINE):
+        updated += NEWLINE
+
+    return updated
+
+
+def test_append_when_marker_is_absent() -> None:
+    managed_block = Path('GLOBAL_CONTRIBUTING.md').read_text()
+    original = '# Local repo guide\n\nRepo-specific instructions.\n'
+
+    updated = sync_global_contributing(original, managed_block)
+
+    assert updated.startswith('# Local repo guide\n\nRepo-specific instructions.\n\n')
+    assert START_MARKER in updated
+    assert END_MARKER in updated
+    assert updated.count(START_MARKER) == 1
+    assert updated.rstrip().endswith(managed_block.rstrip())
+
+
+def test_replace_existing_managed_block() -> None:
+    managed_block = Path('GLOBAL_CONTRIBUTING.md').read_text()
+    original = (
+        '# Local repo guide\n\nKeep this above.\n\n'
+        + START_MARKER
+        + '\nOld managed text that should disappear.\n'
+        + END_MARKER
+        + '\n'
+    )
+
+    updated = sync_global_contributing(original, managed_block)
+
+    assert updated.startswith('# Local repo guide\n\nKeep this above.\n\n')
+    assert 'Old managed text that should disappear.' not in updated
+    assert updated.count(START_MARKER) == 1
+    assert updated.count(END_MARKER) == 1
+    assert updated.rstrip().endswith(managed_block.rstrip())
+
+
+if __name__ == '__main__':
+    test_append_when_marker_is_absent()
+    test_replace_existing_managed_block()
+    print('Global CONTRIBUTING sync tests passed.')


### PR DESCRIPTION
## Summary

This changes the file sync flow so Micronaut repos can keep owning their local `CONTRIBUTING.md` content while still receiving a centrally managed shared section.

Instead of copying `CONTRIBUTING.md` from the template repo, the sync workflow now injects a managed block from `GLOBAL_CONTRIBUTING.md` into each target repo:

- if the target `CONTRIBUTING.md` does not contain the marker, the shared block is appended
- if the target `CONTRIBUTING.md` already contains the marker, everything from that marker onward is replaced with the current shared block
- if `CONTRIBUTING.md.lock` exists, the sync step skips the file entirely

The managed block starts with an explicit warning comment telling maintainers not to add content below that point because the sync workflow will replace it.

## Implementation details

- added `GLOBAL_CONTRIBUTING.md` as the central source for shared contributing guidance
- updated `.github/workflows/files-sync.yml` to call a tracked Python script instead of using inline sync logic
- kept `CONTRIBUTING.md` out of the file copy allowlist so repo-specific content is preserved
- added a template-repo-only CI workflow for the sync behavior and markdown linting
- pinned `markdownlint-cli2` and set up Node 20 in the validation workflow for deterministic CI behavior

## Validation

Ran locally:

- `python3 test-scripts/test_global_contributing_sync.py`
- `python3 test-scripts/test_global_contributing_sync.py --source-root . --target-root . --write`
- `npx --yes markdownlint-cli2@0.22.0 GLOBAL_CONTRIBUTING.md`

Also checked diagnostics for:

- `.github/workflows/files-sync.yml`
- `.github/workflows/contributing-sync-validation.yml`
- `test-scripts/test_global_contributing_sync.py`
