### PR TITLE
Harden PR workflow secret handling

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -25,9 +25,9 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/build-matrix@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: build-matrix
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
         with:
           java-version: '25'
   build:
@@ -50,9 +50,9 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/pre-build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: pre-build
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
         with:
           distribution: 'graalvm'
           gradle-java: '25'
@@ -62,11 +62,11 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: build
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event_name == 'push' && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+          GH_USERNAME: ${{ github.event_name == 'push' && secrets.GH_USERNAME || '' }}
           GRAALVM_QUICK_BUILD: true
         with:
           nativeTestTask: ${{ matrix.native_test_task }}
@@ -74,8 +74,8 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/post-build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: post-build
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
         with:
           java: ${{ matrix.java }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
         java: ['25']
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
-      SONAR_TOKEN_AVAILABLE: ${{ secrets.SONAR_TOKEN != '' }}
+      SONAR_TOKEN_AVAILABLE: ${{ github.event_name == 'push' && secrets.SONAR_TOKEN != '' && 'true' || 'false' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
       - name: "🔧 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -62,18 +62,18 @@ jobs:
       - name: "🛠 Build with Gradle"
         id: gradle
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
-          OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event_name == 'push' && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+          GH_USERNAME: ${{ github.event_name == 'push' && secrets.GH_USERNAME || '' }}
+          OSS_INDEX_USERNAME: ${{ github.event_name == 'push' && secrets.OSS_INDEX_USERNAME || '' }}
+          OSS_INDEX_PASSWORD: ${{ github.event_name == 'push' && secrets.OSS_INDEX_PASSWORD || '' }}
         run: |
           ./gradlew check jacocoReport --no-daemon --continue
 
       - name: "🔎 Run static analysis"
-        if: env.SONAR_TOKEN_AVAILABLE == 'true' && matrix.java == '25'
+        if: github.event_name == 'push' && env.SONAR_TOKEN_AVAILABLE == 'true' && matrix.java == '25'
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
       - name: "🔧 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -60,16 +60,16 @@ jobs:
           [ -f ./setup.sh ] && ./setup.sh || [ ! -f ./setup.sh ]
 
       - name: "🚔 Sonatype Scan"
-        if: env.OSS_INDEX_PASSWORD_AVAILABLE == 'true' && matrix.java == '25'
+        if: github.event_name == 'push' && env.OSS_INDEX_PASSWORD_AVAILABLE == 'true' && matrix.java == '25'
         id: sonatypescan
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
-          OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}
+          DEVELOCITY_CACHE_USERNAME: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_USERNAME || '' }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD || '' }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ github.event_name == 'push' && secrets.GH_TOKEN_PUBLIC_REPOS_READONLY || '' }}
+          GH_USERNAME: ${{ github.event_name == 'push' && secrets.GH_USERNAME || '' }}
+          OSS_INDEX_USERNAME: ${{ github.event_name == 'push' && secrets.OSS_INDEX_USERNAME || '' }}
+          OSS_INDEX_PASSWORD: ${{ github.event_name == 'push' && secrets.OSS_INDEX_PASSWORD || '' }}
         run: |
           ./gradlew ossIndexAudit --no-parallel --info
 

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -22,7 +22,7 @@ jobs:
         java: ['25']
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
-      OSS_INDEX_PASSWORD_AVAILABLE: ${{ secrets.OSS_INDEX_PASSWORD != '' }}
+      OSS_INDEX_PASSWORD_AVAILABLE: ${{ github.event_name == 'push' && secrets.OSS_INDEX_PASSWORD != '' && 'true' || 'false' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs


### PR DESCRIPTION
## Summary
- stop exposing Develocity, Sonar, OSS Index, and shared GitHub credentials to repository-controlled `pull_request` jobs in the synced template workflows
- keep pull request CI coverage by resolving those credentials to empty strings on untrusted events and gating the Sonar and Sonatype scans to trusted `push` runs
- use the built-in `${{ github.token }}` for `setup-graalvm` instead of routing that input through repository secrets

## Verification
- `git diff --check origin/master...HEAD`
- local YAML parse of `.github/workflows/gradle.yml`, `.github/workflows/graalvm-latest.yml`, and `.github/workflows/sonatype.yml`
- targeted secret-handling scan confirming no repository secret remains reachable from `pull_request` in those workflows without a trusted `push` gate or `${{ github.token }}` substitution

## Release Tracking
- QA-selected Micronaut organization project: `5.0.0-M3`
- Ambiguity note: `5.0.0 Release` is also plausible for template-sync work
- Linked GitHub issue: none
- Closing keyword: none

---
###### ✨ This message was AI-generated using gpt-5
