### PR TITLE
Move release history to the bottom of generated guide

### DIFF
--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,7 +1,6 @@
 introduction:
   title: Introduction
-releaseHistory: Release History
 quickStart:
   title: Quick Start
 repository: Repository
-
+releaseHistory: Release History


### PR DESCRIPTION
## Summary
- Move `Release History` to the bottom of the generated guide navigation.
- Keep the existing guide content unchanged; this only reorders `src/main/docs/guide/toc.yml`.

## Validation
- `git diff --check origin/master...HEAD`
- `./gradlew publishGuide` passed during implementation/QA.
- `./gradlew docs` passed during implementation.
- QA confirmed generated guide order: Introduction, Quick Start, Repository, Release History.

## Release Boards
Selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`.

Ambiguity note: this repository's GitHub release metadata is draft-only, so the project choice follows the current Micronaut organization release boards identified during QA intake.

Closes #482

---
###### ✨ This message was AI-generated using gpt-5
