### PR TITLE
Ignore GraalVM workflows during files sync

### DIFF
--- a/.github/workflows/.rsync-filter
+++ b/.github/workflows/.rsync-filter
@@ -1,6 +1,8 @@
 - files-sync.yml
 - test-files-sync.yml
 - update-gradle-wrapper.yml
+- graalvm-dev.yml
+- graalvm-latest.yml
 - .rsync-filter
 - template-cleanup.yml
 - skills-validation.yml

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -119,13 +119,17 @@ We have a [template repo](https://github.com/micronaut-projects/micronaut-projec
 source of truth for certain files. It is used as a template to create new repos, and changes to certain files in the
 template repo will get propagated automatically. The files propagated are:
 
-* Workflow files (`.github/workflows/*`). They are copied using rsync"
+* Workflow files (`.github/workflows/*`). They are copied using rsync:
   * `central-sync.yml`.
-  * `dependency-update.yml`.
-  * `graalvm.yml`.
   * `gradle.yml`.
+  * `publish-snapshot.yml`.
   * `release.yml`.
-  * `release-notes.yml`.
+  * `sonatype.yml`.
+
+The `graalvm-dev.yml` and `graalvm-latest.yml` workflows were synced once to downstream projects and are now excluded
+from future files sync runs. Future changes to those workflows are maintained through
+[`micronaut-projects/github-actions`](https://github.com/micronaut-projects/github-actions/tree/master/graalvm).
+
 * Renovate configuration (`.github/renovate.json`).
 * Gradle wrapper.
 * `.gitignore`.


### PR DESCRIPTION
## Summary
- exclude `graalvm-dev.yml` and `graalvm-latest.yml` from future workflow file sync runs
- document the GraalVM workflow handoff to `micronaut-projects/github-actions`

Closes #360

## Verification
- `git diff --check HEAD~1..HEAD`
- `rsync --dry-run --archive -F --out-format='%n' .github/workflows/ "$tmpdir/"`

## Release Metadata
- Type: `type: improvement`
- Organization projects: no QA intake artifact selected a live project set; the linked issue has no project items, and no project link was applied.

---
###### ✨ This message was AI-generated using gpt-5