### PR TITLE
Enable Checkstyle wildcard import rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -116,7 +116,7 @@
 
         <!-- Checks for imports                              -->
         <!-- See https://checkstyle.org/config_import.html -->
-        <!-- <module name="AvoidStarImport"/> -->
+        <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports">


### PR DESCRIPTION
## Summary
- Enable the existing Checkstyle `AvoidStarImport` rule in the shared template configuration.
- Keep the change limited to `config/checkstyle/checkstyle.xml` so downstream repositories receive the import-style rule through the normal template sync.

## Verification
- `./gradlew :project-template:checkstyleMain --no-daemon`
- Temporary negative probe verified Checkstyle reports `Using the '.*' form of import should be avoided - java.util.*. [AvoidStarImport]`; the probe was removed before publishing.
- `git diff --check origin/master...HEAD`

## Release Boards
QA selected the open Micronaut organization projects `5.0.0-M3` and `5.0.0 Release` as the best-fit project set for this next-major-line template change. That choice carries the upstream ambiguity that both prerelease and GA boards are live, so both are intentionally linked.

Closes #106

---
###### ✨ This message was AI-generated using gpt-5