### PR TITLE
run sonatype vuln scan only on gradle/libs.versions.toml

### DIFF
--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -5,14 +5,11 @@
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: Sonatype Vuln Scan
 on:
-  push:
-    branches:
-      - master
-      - '[0-9]+.[0-9]+.x'
   pull_request:
     branches:
-      - master
       - '[0-9]+.[0-9]+.x'
+    paths:
+      - 'gradle/libs.versions.toml'
 jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'


### PR DESCRIPTION
see: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
