### PR TITLE
Include publication metadata in release artifact ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,15 @@ jobs:
         id: hash
         run: |
           # Find all files in the local publication repository.
-          mapfile -d '' ARTIFACTS < <(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
-              -type f -print0 | sort -z)
+          cd build/repo
+          mapfile -d '' ARTIFACTS < <(find . -type f -printf '%P\0' | sort -z)
           if [[ ${#ARTIFACTS[@]} -eq 0 ]]; then
             echo "No publication artifacts found" >&2
             exit 1
           fi
           # Compute the hashes for the publication artifacts.
-          HASHES=$(sha256sum "${ARTIFACTS[@]}" | base64 -w0)
+          HASHES=$(sha256sum -- "${ARTIFACTS[@]}" | base64 -w0)
+          cd ../..
           # Set the hash as job output for debugging.
           echo "artifacts-sha256=$HASHES" >> "$GITHUB_OUTPUT"
           # Store the hash in a file, which is uploaded as a workflow artifact.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
 
   github_release:
     needs: [release, provenance]
+    permissions:
+      contents: write # To add assets to a release.
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,19 @@ jobs:
       - name: Generate subject
         id: hash
         run: |
-          # Find the artifact JAR and POM files in the local repository.
-          ARTIFACTS=$(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
-              -type f \( \( -iname "*.jar" -not -iname "*-javadoc.jar" -not -iname "*-sources.jar" \) -or -iname "*.pom" \))
-          # Compute the hashes for the artifacts.
+          # Find all files in the local publication repository.
+          mapfile -d '' ARTIFACTS < <(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
+              -type f -print0 | sort -z)
+          if [[ ${#ARTIFACTS[@]} -eq 0 ]]; then
+            echo "No publication artifacts found" >&2
+            exit 1
+          fi
+          # Compute the hashes for the publication artifacts.
+          HASHES=$(sha256sum "${ARTIFACTS[@]}" | base64 -w0)
           # Set the hash as job output for debugging.
-          echo "artifacts-sha256=$(sha256sum $ARTIFACTS | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "artifacts-sha256=$HASHES" >> "$GITHUB_OUTPUT"
           # Store the hash in a file, which is uploaded as a workflow artifact.
-          sha256sum $ARTIFACTS | base64 -w0 > artifacts-sha256
+          echo -n "$HASHES" > artifacts-sha256
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -166,8 +171,8 @@ jobs:
       - name: Create artifacts archive
         shell: bash
         run: |
-          find build/repo -type f \( \( -iname "*.jar" -not -iname "*-javadoc.jar" -not \
-              -iname "*-sources.jar" \) -or -iname "*.pom" \) | xargs zip artifacts.zip
+          cd build/repo
+          find . -type f -printf '%P\n' | sort | zip -q -@ ../../artifacts.zip
       - name: Upload assets
         # Upload the artifacts to the existing release. Note that the SLSA provenance will
         # attest to each artifact file and not the aggregated ZIP file.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gradle-build-outputs
-          path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
+          path: build/repo
           retention-days: 5
       - name: Upload artifacts-sha256
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
This updates the release workflow so `artifacts.zip` contains the full publication repository produced under `build/repo` instead of only main JAR and POM files.

Summary:
- hash every regular file in the local publication repository for SLSA provenance subjects
- upload/download `build/repo` as the artifact root so Maven repository-relative paths are preserved
- create `artifacts.zip` from all downloaded publication files, including signatures, checksums, sources, javadocs, module metadata, and Maven metadata

Verification:
- `git diff --check origin/master...HEAD`
- PyYAML parse of `.github/workflows/release.yml`
- local fixture comparing decoded SLSA subject filenames with final ZIP entries, including `.asc`, `.md5`, `.sha1`, `.sha256`, `.sha512`, sources, javadocs, `.module`, and `maven-metadata.xml`

Release project note: QA identified `5.1.0 Release` as the best-fit project because the synced issue is already on that board, with an ambiguity note that maintainers may revisit active `5.0.0` boards if they schedule this workflow-template change with that release train.

Closes micronaut-projects/micronaut-build#771

---
###### ✨ This message was AI-generated using gpt-5
