### PR TITLE
Replace OSS Index vulnerability scan

### DIFF
--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -35,11 +35,19 @@ initscript {
 
 allprojects {
     apply plugin: Class.forName('org.cyclonedx.gradle.CyclonedxPlugin')
+
+    tasks.withType(Class.forName('org.cyclonedx.gradle.CyclonedxDirectTask')).configureEach { task ->
+        task.enabled = false
+        task.includeConfigs.set(['runtimeClasspath'])
+        plugins.withId('maven-publish') {
+            task.enabled = true
+        }
+    }
 }
 GRADLE
 
 echo "Generating CycloneDX SBOM at ${SBOM_PATH}"
-./gradlew cyclonedxBom --init-script "${init_script}" --no-parallel --info
+./gradlew :cyclonedxBom --init-script "${init_script}" --no-parallel --info
 
 if [[ ! -s "${SBOM_PATH}" ]]; then
     echo "CycloneDX SBOM was not generated at ${SBOM_PATH}" >&2

--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly CYCLONEDX_GRADLE_PLUGIN_VERSION="${CYCLONEDX_GRADLE_PLUGIN_VERSION:-3.2.4}"
+readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.5@sha256:4d3d1a42ba435ac706286fec518c044f049c9753d21260b5bae60bab8740ed97}"
+readonly SBOM_PATH="${SBOM_PATH:-build/reports/cyclonedx/bom.json}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ ! -x ./gradlew ]]; then
+    echo "Gradle wrapper not found or not executable at ${ROOT_DIR}/gradlew" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required to run OSV-Scanner" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+init_script="${tmp_dir}/cyclonedx-init.gradle"
+cat > "${init_script}" <<GRADLE
+initscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.cyclonedx:cyclonedx-gradle-plugin:${CYCLONEDX_GRADLE_PLUGIN_VERSION}"
+    }
+}
+
+allprojects {
+    apply plugin: Class.forName('org.cyclonedx.gradle.CyclonedxPlugin')
+}
+GRADLE
+
+echo "Generating CycloneDX SBOM at ${SBOM_PATH}"
+./gradlew cyclonedxBom --init-script "${init_script}" --no-parallel --info
+
+if [[ ! -s "${SBOM_PATH}" ]]; then
+    echo "CycloneDX SBOM was not generated at ${SBOM_PATH}" >&2
+    exit 1
+fi
+
+osv_args=(
+    run
+    --rm
+    -v "${ROOT_DIR}:/src:ro"
+    -w /src
+    "${OSV_SCANNER_IMAGE}"
+    scan
+    source
+    --experimental-no-default-plugins
+    --experimental-plugins
+    sbom
+    --lockfile
+    "/src/${SBOM_PATH}"
+    --verbosity
+    warn
+)
+
+if [[ -f osv-scanner.toml ]]; then
+    echo "Using osv-scanner.toml for vulnerability audit exceptions"
+    osv_args+=(--config /src/osv-scanner.toml)
+fi
+
+echo "Scanning CycloneDX SBOM with OSV-Scanner"
+docker "${osv_args[@]}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -67,8 +67,6 @@ jobs:
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
-          OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
         run: |
           ./gradlew check jacocoReport --no-daemon --continue
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,19 @@ jobs:
           distribution: 'temurin'
           java-version: |
             25
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       - name: Set the current release version
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+      - name: Vulnerability Audit
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+        run: .github/scripts/vulnerability-audit.sh
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         env:

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -3,15 +3,29 @@
 # https://github.com/micronaut-projects/micronaut-project-template/tree/master/.github/workflows
 #
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
-name: Sonatype Vuln Scan
+name: Vulnerability Audit
 on:
   pull_request:
     branches:
       - '[0-9]+.[0-9]+.x'
     paths:
+      - '**/*.gradle'
+      - '**/*.gradle.kts'
+      - 'gradle.properties'
+      - 'settings.gradle'
+      - 'settings.gradle.kts'
       - 'gradle/libs.versions.toml'
+      - 'gradle/wrapper/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '**/gradle.lockfile'
+      - '**/versions.lock'
+      - 'osv-scanner.toml'
+      - '.github/workflows/sonatype.yml'
+      - '.github/workflows/release.yml'
+      - '.github/scripts/vulnerability-audit.sh'
 jobs:
-  build:
+  audit:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:
@@ -19,7 +33,6 @@ jobs:
         java: ['25']
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
-      OSS_INDEX_PASSWORD_AVAILABLE: ${{ secrets.OSS_INDEX_PASSWORD != '' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs
@@ -56,19 +69,16 @@ jobs:
         run: |
           [ -f ./setup.sh ] && ./setup.sh || [ ! -f ./setup.sh ]
 
-      - name: "🚔 Sonatype Scan"
-        if: env.OSS_INDEX_PASSWORD_AVAILABLE == 'true' && matrix.java == '25'
-        id: sonatypescan
+      - name: "🚔 Vulnerability Audit"
+        if: matrix.java == '25'
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
-          OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
         run: |
-          ./gradlew ossIndexAudit --no-parallel --info
+          .github/scripts/vulnerability-audit.sh
 
       - name: "❓ Optional cleanup step"
         run: |


### PR DESCRIPTION
## Summary

- Replace the OSS Index audit workflow with a separate OSV + CycloneDX vulnerability audit workflow.
- Add a shared `.github/scripts/vulnerability-audit.sh` script used by both the dependency-scoped PR audit workflow and the release workflow.
- Run the release vulnerability gate before pre-release mutation and Maven Central publishing.
- Remove stale OSS Index credentials from normal Gradle CI without adding scanner work to that workflow.

Closes #692.

## Verification

- `bash -n .github/scripts/vulnerability-audit.sh`
- YAML parse for `.github/workflows/gradle.yml`, `.github/workflows/sonatype.yml`, and `.github/workflows/release.yml`
- `git diff --check origin/master...HEAD`
- Targeted check that no OSS Index references remain in the reviewed repository surface
- Targeted check that normal Gradle CI has no vulnerability audit references and release ordering is `Vulnerability Audit` before `Run pre-release` before `Publish to Sonatype OSSRH`

## Project Notes

QA selected Micronaut organization projects `5.0.0-M3` and `5.0.0 Release`. Ambiguity preserved: `micronaut-project-template` itself has no published stable release, so this project selection is based on downstream Micronaut Platform consumption.

Maintainer handoff: test the synced workflow in at least one downstream Micronaut repository before broad sync, because the template workflow keeps the existing guard that prevents it from running in `micronaut-projects/micronaut-project-template` itself.

---
###### ✨ This message was AI-generated using gpt-5