### PR TITLE
Pin mutable actions in template cleanup workflow

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -12,11 +12,13 @@ jobs:
     name: Template Cleanup
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'micronaut-project-template'
+    permissions:
+      contents: write
     steps:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Cleanup project
       - name: Cleanup
@@ -46,7 +48,7 @@ jobs:
           git commit -m "Template cleanup"
       # Push changes
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74 # master
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'micronaut-project-template'
     permissions:
-      contents: write
+      contents: read
     steps:
 
       # Check out current repository
@@ -39,16 +39,47 @@ jobs:
           git mv buildSrc/src/main/groovy/io.micronaut.build.internal.project-template-base.gradle "buildSrc/src/main/groovy/io.micronaut.build.internal.${GITHUB_REPOSITORY:29}-base.gradle"
           # Remove clean up template
           rm -rf  .github/workflows/template-cleanup.yml
+
+      # Save modified files
+      - name: Create cleanup patch
+        run: |
+          git add .
+          git diff --cached --binary > template-cleanup.patch
+
+      # Upload cleanup patch
+      - name: Upload cleanup patch
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: template-cleanup-patch
+          path: template-cleanup.patch
+
+  template-cleanup-push:
+    name: Push Template Cleanup
+    runs-on: ubuntu-latest
+    needs: template-cleanup
+    if: github.event.repository.name != 'micronaut-project-template'
+    permissions:
+      contents: write
+    steps:
+
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Download cleanup patch
+      - name: Download cleanup patch
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: template-cleanup-patch
+
       # Commit modified files
       - name: Commit files
         run: |
+          git apply --index template-cleanup.patch
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
           git commit -m "Template cleanup"
+
       # Push changes
       - name: Push changes
-        uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74 # master
-        with:
-          branch: ${{ github.ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin "HEAD:${GITHUB_REF}"


### PR DESCRIPTION
## Summary

- Pin all `template-cleanup.yml` workflow actions to immutable commit SHAs.
- Split template cleanup from repository push so the cleanup job runs with `contents: read`.
- Restrict `contents: write` to a dedicated push job and replace the third-party push action with a local `git push`.

## Review Notes

Paperclip issue: DEV-229. There is no linked GitHub issue for this security-scan follow-up, so this PR intentionally does not use a GitHub closing keyword.

Selected organization projects: none. No QA-intake project set or release-board target was recorded for this workflow-only hardening change.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/template-cleanup.yml")'`
- `git diff --check origin/master...HEAD`
- `rg -n "uses: .*@" .github/workflows/template-cleanup.yml`
- `rg -n "uses: .*@(master|main|v[0-9])" .github/workflows/template-cleanup.yml || true`

---
###### ✨ This message was AI-generated using gpt-5.5