### PR TITLE
Restore GraalVM workflows to files sync

### DIFF
--- a/.github/workflows/.rsync-filter
+++ b/.github/workflows/.rsync-filter
@@ -1,8 +1,6 @@
 - files-sync.yml
 - test-files-sync.yml
 - update-gradle-wrapper.yml
-- graalvm-dev.yml
-- graalvm-latest.yml
 - .rsync-filter
 - template-cleanup.yml
 - skills-validation.yml

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -121,14 +121,12 @@ template repo will get propagated automatically. The files propagated are:
 
 * Workflow files (`.github/workflows/*`). They are copied using rsync:
   * `central-sync.yml`.
+  * `graalvm-dev.yml`.
+  * `graalvm-latest.yml`.
   * `gradle.yml`.
   * `publish-snapshot.yml`.
   * `release.yml`.
   * `sonatype.yml`.
-
-The `graalvm-dev.yml` and `graalvm-latest.yml` workflows were synced once to downstream projects and are now excluded
-from future files sync runs. Future changes to those workflows are maintained through
-[`micronaut-projects/github-actions`](https://github.com/micronaut-projects/github-actions/tree/master/graalvm).
 
 * Renovate configuration (`.github/renovate.json`).
 * Gradle wrapper.


### PR DESCRIPTION
## Summary
- return `graalvm-dev.yml` and `graalvm-latest.yml` to workflow files-sync propagation by removing their rsync-filter exclusions
- update `MAINTAINING.md` so the synced workflow list matches the restored behavior

Fixes #699.

## Verification
- `git diff --check origin/master...HEAD`
- `rsync --dry-run --archive -F --out-format='%n' .github/workflows/ <tmp-target>/` includes `graalvm-dev.yml` and `graalvm-latest.yml`; `files-sync.yml` remains excluded

## Release Targeting
- Target branch: `master`
- Type: `type: improvement`
- Selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`
- Ambiguity preserved from intake: this template repository reports `projectVersion=1.0.0-SNAPSHOT` and has no stable non-prerelease release, while the imported issue reports Version `5.0.0`; the PR is treated as Micronaut 5.0.0 workflow/template readiness.

---
###### ✨ This message was AI-generated using gpt-5
