### PR TITLE
Fixed GraalVM Dev CI github workflow

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Build Matrix
         uses: micronaut-projects/github-actions/graalvm/build-matrix@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: build-matrix
+        with:
+          java-version: '25'
   build:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
@@ -55,6 +57,7 @@ jobs:
           java: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
           nativeTestTask: ${{ matrix.native_test_task }}
+          gradle-java: '25'
       - name: Build Steps
         uses: micronaut-projects/github-actions/graalvm/build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         id: build


### PR DESCRIPTION
Fixed the following issue which happened for `build_matrix` and `build` jobs in `GraalVM Dev CI` (graalvm-dev.yml) workflow:
```
Could not resolve all artifacts for configuration 'classpath'.
> Could not resolve io.micronaut.build.internal:micronaut-gradle-plugins:8.0.0-M18.
  Required by:
      settings file 'settings.gradle' > io.micronaut.build.shared.settings:io.micronaut.build.shared.settings.gradle.plugin:8.0.0-M18
   > Dependency requires at least JVM runtime version 25. This build uses a Java 21 JVM.
```