### PR TITLE
Add Micronaut Guides skill

### DIFF
--- a/.agents/skills/guides/SKILL.md
+++ b/.agents/skills/guides/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: guides
+description: Create or update standalone Micronaut Guides in micronaut-projects/micronaut-guides, including topic discovery, guide authoring, validation, PDF export, and pull request handoff. Use for requests to create a Micronaut Guide, add a guide to micronaut-guides, author a tutorial for a Micronaut module, or prepare a guide PR with PDF.
+license: Apache-2.0
+compatibility: Micronaut Guides repository and Micronaut repositories that need standalone tutorial PRs
+metadata:
+  author: Micronaut Agent Company
+  version: "1.0.0"
+---
+
+# Guides (Micronaut Maintainer)
+
+Use this skill for standalone tutorial work in `micronaut-projects/micronaut-guides`. Start from the caller's local Micronaut repository to understand the API, module, or behavior being taught, then do the guide implementation in a current clone of `micronaut-guides`.
+
+Do not use this skill for ordinary module documentation under `src/main/docs/guide`; use the `docs` skill for that work. Do not use it for generic non-Micronaut tutorials.
+
+## Goal
+
+Produce a reviewable pull request against `micronaut-projects/micronaut-guides` with source-backed guide content, validation evidence, and a PDF export of the rendered guide page for maintainers.
+
+## Procedure
+
+1. Define the topic from the local repository.
+2. Refresh upstream `micronaut-guides` and deduplicate against existing guides.
+3. Inspect current repository conventions before writing.
+4. Author the smallest correct guide change.
+5. Validate the guide and render the page.
+6. Export a PDF and prepare the PR handoff.
+
+### 1) Define the Topic
+
+- Identify the exact Micronaut feature, module, API, integration, or migration path the guide should teach.
+- Read the local implementation, tests, module docs, and examples that prove the behavior.
+- Decide the target reader task in one sentence, for example: "Use Micronaut Serialization with a custom serializer in a controller response."
+- Prefer a runnable application and tests over prose-only explanation.
+
+### 2) Refresh and Deduplicate
+
+Work from current upstream facts, not this skill's snapshot:
+
+```bash
+git clone https://github.com/micronaut-projects/micronaut-guides.git
+cd micronaut-guides
+git fetch origin
+git switch master
+git pull --ff-only
+```
+
+Before creating a new guide, inventory `guides/*/metadata.json` and nearby guide source. Check titles, slugs, tags, categories, `apps`, `base`, `publish`, and guide bodies for duplicates or near-duplicates. Treat `publish: false` guides as base or partial guides, not public topics, but inspect them when a new guide could reuse them.
+
+If an existing guide already teaches the task, update that guide instead of creating a duplicate. If overlap is ambiguous, stop and ask for maintainer direction.
+
+### 3) Inspect Current Conventions
+
+Always read these current upstream files before editing:
+
+- `README.md`
+- `build.gradle`
+- `buildSrc/src/main/java/io/micronaut/guides/core/Guide.java`
+- `buildSrc/src/main/java/io/micronaut/guides/Category.java`
+- `buildSrc/src/main/resources/guide-metadata.schema.json`
+- Nearby guides in the same topic family
+
+Use `references/repository-workflow.md` for clone, branch, build-output, task naming, and validation details. Use `references/guide-authoring-conventions.md` for metadata, directory layout, macros, placeholders, and base-guide rules.
+
+### 4) Author the Guide
+
+- Choose a kebab-case slug that matches the reader task and does not collide with existing guide directories.
+- Create or update `guides/<slug>/metadata.json`.
+- Use one root AsciiDoc file named `<slug>.adoc` unless current metadata conventions require `asciidoctor`.
+- Put source under the expected Java, Groovy, and Kotlin layout when the guide supports multiple languages. If the feature is language-specific, set `languages` in metadata and explain why in the PR.
+- For single-app guides, use an app named `default`. For multi-app guides, mirror existing app-directory patterns and declare each app in metadata.
+- Use validated guide macros such as `common:`, `source:`, `resource:`, `test:`, `testResource:`, `callout:`, `external:`, `dependency:`, and `guideLink:` instead of manually duplicating generated paths.
+- Use conditional blocks such as `:exclude-for-languages:` and `:exclude-for-build:` for language-specific or build-tool-specific text.
+- Keep secrets out of source, generated code, rendered HTML, and the PDF. Use placeholders and documented cleanup steps for cloud resources.
+
+### 5) Validate
+
+Convert the guide slug from kebab-case to lowerCamelCase for dynamic tasks:
+
+```bash
+./gradlew <guideLowerCamel>Build
+./gradlew <guideLowerCamel>RunTestScript
+```
+
+For broad validation or shared infrastructure changes, run:
+
+```bash
+./gradlew build
+```
+
+Generated applications are under `build/code`. Rendered HTML and site assets are under `build/dist`. For cloud, credentialed, or cost-incurring guides, do not run provisioning commands without explicit confirmation; document skipped validation and the reason.
+
+### 6) Export PDF and Handoff
+
+After rendering, export the reviewed HTML page to PDF. Prefer a headless browser export when available, and fall back to a manual browser "Print to PDF" export when needed. Keep the PDF as local review evidence or attach it to the PR; do not commit generated PDFs unless maintainers explicitly request that.
+
+The PR body must include:
+
+- Guide slug and user-facing task.
+- Files changed.
+- Commands run and outcomes.
+- Rendered HTML path inspected.
+- PDF filename and whether it is attached or linked.
+- Any skipped validation, cloud costs, credentials, or cleanup notes.
+
+See `references/pdf-export-and-pr.md` for the export workflow and PR checklist.
+
+## Security Guardrails
+
+- Never commit secrets, tokens, local credentials, cloud account identifiers, `.env` files, or generated PDFs containing private data.
+- Ask before running commands that provision cloud resources or incur cost.
+- Prefer sample placeholders for credentials and explain cleanup for created resources.
+- Scrub screenshots, HTML, logs, and PDFs before attaching them to a PR.
+- Do not add custom Starter features, dependencies, or buildSrc changes unless the guide topic requires them and nearby guide conventions support the change.
+
+## Examples
+
+Use this skill for:
+
+- "Create a Micronaut Guide for the new serialization feature."
+- "Add a guide to `micronaut-guides` for this module."
+- "Author a tutorial for Micronaut Data's new repository behavior."
+- "Prepare a guide PR with the rendered PDF."
+
+Do not use this skill for:
+
+- "Update `src/main/docs/guide/toc.yml` in this module."
+- "Fix the release history page in this repository."
+- "Write a generic blog post about Java."
+
+## Validation Checklist
+
+- [ ] Current `micronaut-guides` was cloned or fetched before writing.
+- [ ] Existing guide titles, slugs, tags, categories, and `publish: false` bases were checked for duplicates.
+- [ ] `README.md`, metadata schema, category source, and nearby guide examples were inspected.
+- [ ] Guide source uses current metadata, directory, macro, language, and build-tool conventions.
+- [ ] Single-guide build and test-script tasks were run, or skipped with a specific reason.
+- [ ] Rendered HTML was inspected under `build/dist`.
+- [ ] PDF export was created and named in the PR handoff.
+- [ ] PR handoff explains changed files, validation, skipped steps, and any security-sensitive handling.
+
+## References
+
+- `references/repository-workflow.md`
+- `references/guide-authoring-conventions.md`
+- `references/guide-inventory.md`
+- `references/pdf-export-and-pr.md`

--- a/.agents/skills/guides/references/guide-authoring-conventions.md
+++ b/.agents/skills/guides/references/guide-authoring-conventions.md
@@ -1,0 +1,151 @@
+# Guide Authoring Conventions
+
+Micronaut Guides are generated tutorials. A single guide source can render several language and build-tool variants, so write source-backed content and avoid hard-coded generated paths where guide macros can do the work.
+
+## Guide Directory
+
+A regular guide normally lives at:
+
+```text
+guides/<slug>/
+|-- metadata.json
+|-- <slug>.adoc
+|-- java/
+|-- groovy/
+|-- kotlin/
+`-- src/main/resources/
+```
+
+Use one root AsciiDoc file named `<slug>.adoc` unless `metadata.json` sets `asciidoctor`.
+
+For a single generated application, metadata should use an app named `default`. For multi-application guides, create a directory per app name and place each language tree inside that app directory:
+
+```text
+guides/<slug>/<app-name>/java/src/main/java/example/micronaut/...
+guides/<slug>/<app-name>/kotlin/src/main/kotlin/example/micronaut/...
+guides/<slug>/<app-name>/groovy/src/main/groovy/example/micronaut/...
+```
+
+## Metadata
+
+Current upstream metadata is modeled by `buildSrc/src/main/java/io/micronaut/guides/core/Guide.java` and the generated schema at `buildSrc/src/main/resources/guide-metadata.schema.json`.
+
+Required fields:
+
+- `title`
+- `intro`
+- non-empty `authors`
+- non-empty `categories`
+- `publicationDate` in `YYYY-MM-DD`
+- non-empty `apps`
+
+Common optional fields:
+
+- `minimumJavaVersion`
+- `maximumJavaVersion`
+- `cloud`
+- `skipGradleTests`
+- `skipMavenTests`
+- `asciidoctor`
+- `languages`
+- `tags`
+- `buildTools`
+- `testFramework`
+- `zipIncludes`
+- `slug`
+- `publish`
+- `base`
+- `env`
+
+Use category labels from `Category.java`. At the inspected upstream revision, labels included Getting Started, Core Basics, Validation, Development, Testing, MCP, Object Storage, Email, Messaging, Logging, Scheduling, Cache, Patterns, i18n, Database Modeling, Data JDBC, Data JPA, Schema Migration, Data R2DBC, MongoDB, Data Access, Micronaut Security, Authorization Code, Client Credentials, Secrets Manager, HTTP Server, HTTP Client, Beyond JSON, JAX-RS, WebSockets, GraphQL, OpenAPI, JSON Schema, Distributed Tracing, Service Discovery, Distributed Configuration, Metrics, Distribution, Registry, GraalVM, Coordinated Restore at Checkpoint, Kubernetes, Serverless, AWS Lambda, Scale to Zero Containers, Views, Turbo, Static Resources, Kotlin, GraalPy, Spring Boot, and Boot to Micronaut Building a REST API. Refresh this list from current upstream before choosing a category.
+
+## Starter Features and Apps
+
+Guide `apps` features must be valid Micronaut Starter features. If a feature is not available from Starter, inspect existing custom features in `buildSrc/src/main/java/io/micronaut/guides/feature` and dependency versions in `buildSrc/src/main/resources/pom.xml`. Add custom features only when the guide topic requires them and validation covers the change.
+
+Example single-app metadata shape:
+
+```json
+{
+  "title": "Micronaut HTTP Client",
+  "intro": "Learn how to use Micronaut HTTP Client.",
+  "authors": ["Sergio del Amo"],
+  "categories": ["HTTP Client"],
+  "publicationDate": "2026-05-06",
+  "apps": [
+    {
+      "name": "default",
+      "features": ["http-client"]
+    }
+  ]
+}
+```
+
+## AsciiDoc Placeholders
+
+Guide source can use placeholders expanded by the build:
+
+- `@language@`
+- `@guideTitle@`
+- `@guideIntro@`
+- `@micronaut@`
+- `@lang@`
+- `@build@`
+- `@testFramework@`
+- `@authors@`
+- `@languageextension@`
+- `@testsuffix@`
+- `@sourceDir@`
+- `@minJdk@`
+- `@api@`
+- `@features@`
+- `@features-words@`
+
+## Common Snippets and Macros
+
+Reusable snippets live under `src/docs/common`. Prefer existing snippets for headers, requirements, complete-solution, app creation, test, run, GraalVM, and next-step sections.
+
+Common guide macros include:
+
+- `common:<file>[]`: include a common snippet.
+- `source:<ClassName>[]`: include a source file from the current language's main source directory.
+- `resource:<file>[]`: include a resource from `src/main/resources`.
+- `test:<ClassName>[]`: include a test file and account for JUnit, Kotest, or Spock naming.
+- `testResource:<file>[]`: include a test resource.
+- `callout:<name>[]`: include a common callout snippet.
+- `external:<path>[]`: include content from a base or external guide.
+- `dependency:<artifact>[groupId=...,scope=...,version=...]`: render dependency lines.
+- `guideLink:<slug>[...]`: link to another guide using guide-site paths.
+
+Most macros accept options such as `tags`, `lines`, `indent`, and `app`. Inspect nearby guides and buildSrc macro tests before using less common options.
+
+## Conditional Blocks
+
+Use custom exclusion blocks when a paragraph or instruction applies only to some render variants:
+
+```asciidoc
+:exclude-for-languages:kotlin
+This text renders for Java and Groovy, not Kotlin.
+:exclude-for-languages:
+
+:exclude-for-build:maven
+Run `./gradlew run`.
+:exclude-for-build:
+```
+
+Also inspect current support for JDK-based exclusions before writing Java-version-specific content.
+
+## Base and Partial Guides
+
+`publish` defaults to true. Set `publish: false` only for draft, base, or partial guides that should not appear as public guide topics.
+
+Use `base` when a guide extends reusable source or narrative from another guide. Inspect the base guide carefully; it may provide shared app code, common AsciiDoc, or resource files. Do not count `publish: false` guide directories as public topic coverage during dedupe, but do use them to avoid duplicating shared scaffolding.
+
+## Code Quality
+
+- Keep application code runnable and focused on the guide's teaching goal.
+- Put sample code under `example.micronaut` unless nearby guides for the topic use another package.
+- Prefer tests that prove the user's expected outcome.
+- Use snippet tags when only part of a file should appear in the guide.
+- Avoid prose that drifts from the code; include actual source, resources, and tests with guide macros.
+- For cloud and security guides, use placeholders for secrets and include cleanup instructions.

--- a/.agents/skills/guides/references/guide-inventory.md
+++ b/.agents/skills/guides/references/guide-inventory.md
@@ -1,0 +1,121 @@
+# Guide Inventory Snapshot
+
+Snapshot generated from `micronaut-projects/micronaut-guides` `master` at commit `3e6d159` on 2026-05-06 during DEV-256 implementation.
+
+This is a navigation aid, not a source of truth. Regenerate from current upstream before deciding that a topic is new.
+
+## Snapshot Summary
+
+- Guide directories under `guides/`: 185.
+- `metadata.json` files under guide directories: 185.
+- Common snippets live under `src/docs/common`.
+- Metadata model: `buildSrc/src/main/java/io/micronaut/guides/core/Guide.java`.
+- Category labels: `buildSrc/src/main/java/io/micronaut/guides/Category.java`.
+- Dynamic tasks: guide slug lowerCamelCase plus `Build` or `RunTestScript`.
+
+## Regenerate Inventory
+
+From a fresh `micronaut-guides` checkout:
+
+```bash
+find guides -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
+jq -r '.categories[]? // .category? // empty' guides/*/metadata.json | sort | uniq -c | sort -nr
+jq -r '.tags[]? // empty' guides/*/metadata.json | sort | uniq -c | sort -nr
+rg -n '"publish": false|"base"' guides/*/metadata.json
+```
+
+If `jq` output is noisy because of shell or filter precedence, use `rg` for `base` and `publish` first, then inspect the individual metadata files.
+
+## High-Signal Topic Families
+
+Representative families present in the snapshot:
+
+- Getting started and basics: `creating-your-first-micronaut-app`, `micronaut-configuration`, dependency injection, scopes, validation, records.
+- HTTP and APIs: HTTP server, HTTP client, CORS, filters, content negotiation, XML, OpenAPI, JSON Schema, GraphQL, WebSocket.
+- Testing: Rest Assured, MockServer, Testcontainers, Kafka listener testing, security testing.
+- Data: JDBC, JPA, R2DBC, MongoDB, Flyway, Liquibase, jOOQ, many-to-many examples, cloud database variants.
+- Security: basic auth, JWT, cookie JWT, session, API keys, X.509, OAuth2/OIDC providers, client credentials, token propagation.
+- Cloud and serverless: AWS Lambda, Azure Functions, Google Cloud Run, Oracle Cloud, App Engine, cloud secrets, parameter stores, object storage.
+- Messaging and distributed systems: Kafka, RabbitMQ, MQTT, JMS/SQS, service discovery, tracing, metrics.
+- Distribution: executable JARs, Docker images, container registry pushes, GraalVM native image, CRaC, Kubernetes.
+- Server-side HTML: Views, Thymeleaf, Turbo, Hotwire, static resources, WebJars Stimulus.
+- Migration: Spring Boot to Micronaut guide series.
+- AI and tools: MCP stdio/http examples, GraalPy.
+
+## Top Categories in the Snapshot
+
+Highest-count categories at the inspected revision:
+
+- Micronaut Security: 12
+- Authorization Code: 11
+- Distribution: 10
+- AWS Lambda: 10
+- Distributed Tracing: 7
+- Spring Boot, Service Discovery, Messaging, GraalVM, Data JDBC, Boot to Micronaut Building a REST API: 6 each
+- Testing, Secrets Manager, Distributed Configuration, Data Access: 5 each
+- Serverless, OpenAPI, MongoDB, MCP, Kubernetes, Email: 4 each
+
+Refresh before relying on counts.
+
+## Top Tags in the Snapshot
+
+High-frequency tags included:
+
+- `security`
+- `oauth2`
+- `oidc`
+- `cloud`
+- `spring-boot`
+- `database`
+- `validation`
+- `oracle`
+- `micronaut-data`
+- `lambda`
+- `service-discovery`
+- `distributed-tracing`
+
+Use tags for discovery and dedupe, but do not treat them as a substitute for reading guide bodies.
+
+## Base or Partial Guides
+
+The snapshot included these `publish: false` guide directories:
+
+- `distribution-base`
+- `hello-base`
+- `micronaut-cloud-database-base`
+- `micronaut-cloud-oidc-base`
+- `micronaut-cloud-trace-base`
+- `micronaut-data-many-to-many-base`
+- `micronaut-email`
+- `micronaut-mcp-diskspace`
+- `micronaut-mcp-weather`
+- `micronaut-object-storage-base`
+- `micronaut-openapi-base`
+- `micronaut-serverless-function-aws-lambda-request-stream-handler-base`
+
+Common base consumers include cloud database, object storage, OpenAPI, MCP transport variants, email provider variants, and distribution examples. Inspect both the child guide and its base before editing either.
+
+## Representative Guides to Inspect
+
+Choose examples by similarity:
+
+- First application: `creating-your-first-micronaut-app`.
+- Simple HTTP/client source includes: `micronaut-http-client`.
+- Configuration and snippet tags: `micronaut-configuration`.
+- Testing style: `micronaut-rest-assured`, `testing-rest-api-integrations-using-mockserver`.
+- Data JDBC and migrations: `micronaut-data-jdbc-repository`, `micronaut-flyway`, `working-with-jooq-flyway-using-testcontainers`.
+- Security/OIDC: `micronaut-security-jwt`, `micronaut-oauth2-oidc-google`, `micronaut-oauth2-keycloak`.
+- Base-guide reuse: `hello-base` plus `micronaut-cors` or `micronaut-health-endpoint`.
+- Multi-app guide: distributed tracing or service discovery guides.
+- Cloud guide: object storage or cloud database provider variants.
+- OpenAPI: `micronaut-openapi-base`, `micronaut-openapi-generator-client`, `micronaut-openapi-generator-server`.
+- MCP: `micronaut-mcp-weather`, `micronaut-mcp-weather-http`, `micronaut-mcp-weather-stdio`.
+
+## Dedupe Decision
+
+Before creating a new guide, record:
+
+- Proposed slug.
+- Existing guides with matching words, APIs, categories, tags, annotations, dependencies, or generated features.
+- Whether related `publish: false` base guides exist.
+- Why a new guide is warranted, or which existing guide will be updated instead.

--- a/.agents/skills/guides/references/pdf-export-and-pr.md
+++ b/.agents/skills/guides/references/pdf-export-and-pr.md
@@ -1,0 +1,113 @@
+# PDF Export and PR Handoff
+
+Micronaut Guides PRs should include a PDF export of the rendered guide page for review. The PDF is review evidence, not source content. Do not commit it unless maintainers explicitly ask for that.
+
+## Find the Rendered HTML
+
+After running the guide build, inspect `build/dist`.
+
+Common page names:
+
+- `build/dist/<slug>.html`
+- `build/dist/<slug>-gradle-java.html`
+- `build/dist/<slug>-maven-java.html`
+- Other language/build variants such as `-gradle-kotlin`, `-maven-groovy`, depending on metadata.
+
+Open the page that best represents the guide for review. Prefer the default Java/Gradle page if multiple variants render and the PR does not target a language-specific guide.
+
+## Headless Browser Export
+
+If Playwright, Chromium, Chrome, or another headless browser is available, export from the local file or a local static server.
+
+Example with Playwright:
+
+```bash
+GUIDE_SLUG=<slug> node - <<'JS'
+const { chromium } = require('playwright');
+
+(async () => {
+  const slug = process.env.GUIDE_SLUG;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(`file://${process.cwd()}/build/dist/${slug}.html`, { waitUntil: 'networkidle' });
+  await page.pdf({
+    path: `build/review/${slug}.pdf`,
+    format: 'A4',
+    printBackground: true
+  });
+  await browser.close();
+})();
+JS
+```
+
+If you prefer writing a temporary script instead of using an inline heredoc, keep it outside committed source or remove it before finalizing. If the rendered page needs relative assets and file URLs fail, serve `build/dist` locally:
+
+```bash
+python3 -m http.server 8000 --directory build/dist
+```
+
+Then export from `http://127.0.0.1:8000/<slug>.html`.
+
+## Manual Fallback
+
+When headless export tools are unavailable:
+
+1. Open `build/dist/<slug>.html` in a browser.
+2. Use Print.
+3. Select "Save to PDF".
+4. Enable background graphics when available.
+5. Save as `<slug>-guide-preview.pdf`.
+6. Inspect the PDF for missing assets, clipped code blocks, and secrets.
+
+## Filename and Storage
+
+Use a clear filename:
+
+```text
+<slug>-guide-preview.pdf
+```
+
+Prefer local review output such as:
+
+```text
+build/review/<slug>-guide-preview.pdf
+```
+
+Keep the file out of Git unless maintainers explicitly request committed PDFs.
+
+## PR Body Checklist
+
+Include this information in the PR body:
+
+```markdown
+## Summary
+
+- Added/updated the `<slug>` guide for <reader task>.
+- Covers <languages/build tools/apps>.
+
+## Validation
+
+- `./gradlew <guideLowerCamel>Build`
+- `./gradlew <guideLowerCamel>RunTestScript`
+- Rendered HTML inspected: `build/dist/<slug>.html`
+
+## Review PDF
+
+- PDF: `<slug>-guide-preview.pdf`
+- Attached to this PR / linked from <location>.
+
+## Notes
+
+- Skipped validation: <none or exact reason>.
+- Cloud resources: <none or cleanup/cost notes>.
+- Secrets: no secrets or local credentials included in source, logs, HTML, or PDF.
+```
+
+If the PR uses GitHub project metadata, preserve release targeting from the issue or plan. For DEV-256's originating template change, the recommended organization project guidance was `5.0.0-M3` and `5.0.0 Release`, while the template repository itself targets its unreleased `1.0.0` line. Future guide PRs should use the active project/milestone guidance current at the time of the PR.
+
+## Before Uploading
+
+- Re-open the PDF and verify code blocks, navigation, and images are readable.
+- Confirm no credentials, tokens, account IDs, private hostnames, or local paths are visible.
+- Confirm the PDF reflects the latest committed guide source.
+- Mention any known rendering limitation in the PR body.

--- a/.agents/skills/guides/references/repository-workflow.md
+++ b/.agents/skills/guides/references/repository-workflow.md
@@ -1,0 +1,100 @@
+# Micronaut Guides Repository Workflow
+
+This reference records the workflow to use after this skill triggers. Treat it as a checklist, not as a replacement for reading current upstream files.
+
+## Clone and Branch
+
+Create the guide work in `micronaut-projects/micronaut-guides`, not in the source module repository:
+
+```bash
+git clone https://github.com/micronaut-projects/micronaut-guides.git
+cd micronaut-guides
+git fetch origin
+git switch master
+git pull --ff-only
+git switch -c <descriptive-guide-branch>
+```
+
+If a contributor PR already exists, preserve that branch and align documentation work to it instead of silently starting a replacement.
+
+## Files to Inspect Every Time
+
+Read current upstream files before authoring:
+
+- `README.md`: repository structure, build commands, guide creation notes, macro examples, testing workflow.
+- `build.gradle`: site asset flow and output directories.
+- `buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy`: dynamic task names and guide task wiring.
+- `buildSrc/src/main/java/io/micronaut/guides/core/Guide.java`: metadata model.
+- `buildSrc/src/main/resources/guide-metadata.schema.json`: JSON schema generated for metadata validation.
+- `buildSrc/src/main/java/io/micronaut/guides/Category.java`: valid category labels.
+- Nearby `guides/<slug>/metadata.json` and `<slug>.adoc` files in the same category or feature family.
+
+## Output Directories
+
+The Micronaut Guides build generates transient artifacts:
+
+- `build/code`: generated application projects and `test.sh`.
+- `src/doc/asciidoc`: temporary generated AsciiDoc after custom macro expansion.
+- `build/docs/asciidoc`: Asciidoctor output before site theming.
+- `build/dist`: rendered guide site, themed HTML, static assets, generated zips, index, tag pages, and per-guide pages.
+
+Do not commit generated artifacts unless upstream maintainers explicitly request them.
+
+## Dynamic Gradle Task Names
+
+Guide-specific tasks use the guide directory slug converted from kebab-case to lowerCamelCase:
+
+- `micronaut-http-client` -> `micronautHttpClientBuild`
+- `micronaut-http-client` -> `micronautHttpClientRunTestScript`
+
+Run:
+
+```bash
+./gradlew <guideLowerCamel>Build
+./gradlew <guideLowerCamel>RunTestScript
+```
+
+Use full validation when shared build logic, reusable features, common snippets, templates, or broad site generation changed:
+
+```bash
+./gradlew build
+```
+
+## Validation Matrix
+
+Choose the smallest validation that proves the change:
+
+| Change | Minimum validation |
+| --- | --- |
+| New or updated regular guide | `<guideLowerCamel>Build` and `<guideLowerCamel>RunTestScript` |
+| Prose-only AsciiDoc correction | `<guideLowerCamel>Build`, plus inspect rendered HTML |
+| Metadata-only change | `<guideLowerCamel>Build`, plus inspect generated index/category behavior if relevant |
+| Common snippet or macro usage shared by multiple guides | At least one affected guide build, and broader build if many guides are affected |
+| `buildSrc` feature or dependency change | `./gradlew build` unless maintainers approve narrower validation |
+| Cloud or credentialed guide | Build/render locally; run provisioning only with explicit confirmation |
+
+Record skipped commands and the reason in the PR handoff.
+
+## Topic Discovery Commands
+
+Useful inventory commands from the `micronaut-guides` root:
+
+```bash
+find guides -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
+jq -r '.title, (.categories[]? // empty), (.tags[]? // empty)' guides/*/metadata.json
+rg -n "<topic>|<api>|<annotation>|<feature>" guides buildSrc/src/main/java/io/micronaut/guides/feature src/docs/common
+jq -r 'select(.publish == false) | input_filename' guides/*/metadata.json
+rg -n '"base"' guides/*/metadata.json
+```
+
+When deduping, compare the proposed guide against published guide titles, guide slugs, tags, categories, related source files, and base/partial guides.
+
+## Escalation Rules
+
+Stop and ask for direction when:
+
+- The proposed topic duplicates an existing guide.
+- The guide requires a new Starter feature and it is unclear whether `buildSrc/src/main/java/io/micronaut/guides/feature` should own it.
+- Validation depends on paid cloud resources, external accounts, production services, or secrets.
+- The implementation behavior is not proven by local repository code or tests.
+- The guide needs broad architecture or release-policy decisions outside a tutorial PR.


### PR DESCRIPTION
## Summary

- Adds a new `guides` agent skill for standalone Micronaut Guides work in `micronaut-projects/micronaut-guides`.
- Captures repository workflow, guide authoring conventions, inventory/dedupe guidance, and PDF export plus PR handoff requirements.
- Keeps the existing `docs` skill scoped to ordinary module docs under `src/main/docs/guide`.

Closes #704

## Validation

- `ruby -ryaml -rdate ...` parsed all project skill frontmatter and confirmed folder/name matches for 6 skills.
- `ruby ...` verified the 4 `SKILL.md` reference links resolve.
- `LC_ALL=C rg -n "[^\\x00-\\x7F]" .agents/skills/guides || true` found no non-ASCII content.
- `npx --yes skills list | sed -r 's/\\x1B\\[[0-9;]*[mK]//g' | rg 'guides\\s+\\./\\.agents/skills/guides'` confirmed discovery.
- `git ls-remote https://github.com/micronaut-projects/micronaut-guides.git refs/heads/master` confirmed upstream `master` at `3e6d1593188f30f474b0ce94856fca859d617ef1`, matching the analyzed snapshot.
- `skills-ref validate .agents/skills/guides` was not available in this workspace, so the project `skill-creator` spec checklist was applied manually.

## Project Targeting

QA selected Micronaut organization projects `5.0.0-M3` and `5.0.0 Release`. Ambiguity preserved: this template repository targets its unreleased `1.0.0` line, but no open public Micronaut organization project matching `1.0.0` exists; because this skill is intended for propagation across Micronaut repositories, QA selected the closest active Micronaut platform-facing `5.0.0` boards.

---
###### ✨ This message was AI-generated using gpt-5
