### PR TITLE
Filter upstream-owned vulnerability audit findings

### DIFF
--- a/.github/scripts/vulnerability-audit-filter.py
+++ b/.github/scripts/vulnerability-audit-filter.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import json
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+DEFAULT_UPSTREAM_GROUP_PREFIXES = ("io.micronaut",)
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as json_file:
+        return json.load(json_file)
+
+
+def component_ref(component):
+    return component.get("bom-ref") or component.get("purl")
+
+
+def component_group_name(component):
+    group = component.get("group")
+    name = component.get("name")
+    if group and name:
+        return f"{group}:{name}"
+    return name
+
+
+def purl_has_project_path(component):
+    purl = component.get("purl") or component.get("bom-ref") or ""
+    parsed = urlparse(purl)
+    query = parse_qs(parsed.query)
+    return "project_path" in query
+
+
+def parse_prefixes(value):
+    prefixes = []
+    for prefix in value.split(","):
+        prefix = prefix.strip()
+        if prefix:
+            prefixes.append(prefix)
+    return tuple(prefixes)
+
+
+class AuditGraph:
+    def __init__(self, bom, upstream_group_prefixes):
+        metadata_component = bom.get("metadata", {}).get("component", {})
+        self.components = []
+        if metadata_component:
+            self.components.append(metadata_component)
+        self.components.extend(bom.get("components", []))
+
+        self.component_by_ref = {
+            component_ref(component): component
+            for component in self.components
+            if component_ref(component)
+        }
+        self.refs_by_package = collections.defaultdict(list)
+        for component in self.components:
+            group_name = component_group_name(component)
+            version = component.get("version")
+            ref = component_ref(component)
+            if group_name and version and ref:
+                self.refs_by_package[(group_name, version)].append(ref)
+
+        self.dependencies = collections.defaultdict(set)
+        for dependency in bom.get("dependencies", []):
+            ref = dependency.get("ref")
+            if ref:
+                self.dependencies[ref].update(dependency.get("dependsOn", []))
+
+        self.local_roots = {
+            component_ref(component)
+            for component in self.components
+            if component_ref(component) and purl_has_project_path(component)
+        }
+        if not self.local_roots and component_ref(metadata_component):
+            self.local_roots.add(component_ref(metadata_component))
+
+        self.upstream_group_prefixes = upstream_group_prefixes
+
+    def is_upstream_component(self, ref):
+        component = self.component_by_ref.get(ref)
+        if not component or purl_has_project_path(component):
+            return False
+        group = component.get("group", "")
+        return any(
+            group == prefix or group.startswith(f"{prefix}.")
+            for prefix in self.upstream_group_prefixes
+        )
+
+    def classify_package(self, package_name, version):
+        targets = set(self.refs_by_package.get((package_name, version), []))
+        if not targets:
+            return {
+                "classification": "actionable",
+                "reason": "package was not found in the CycloneDX dependency graph",
+                "via": [],
+            }
+        if not self.local_roots:
+            return {
+                "classification": "actionable",
+                "reason": "no local project roots were found in the CycloneDX dependency graph",
+                "via": [],
+            }
+
+        path_count = 0
+        upstream_via = set()
+        actionable_reasons = set()
+
+        for root in sorted(self.local_roots):
+            queue = collections.deque()
+            for child in sorted(self.dependencies.get(root, ())):
+                if child in targets:
+                    path_count += 1
+                    if self.is_upstream_component(child):
+                        upstream_via.add(child)
+                    else:
+                        actionable_reasons.add("direct local dependency")
+                    continue
+                first_upstream = child if self.is_upstream_component(child) else None
+                outside_upstream = child not in self.local_roots and first_upstream is None
+                queue.append((child, first_upstream, outside_upstream, {root, child}))
+
+            while queue:
+                node, first_upstream, outside_upstream, seen = queue.popleft()
+                children = self.dependencies.get(node, ())
+                if not children:
+                    continue
+                for child in sorted(children):
+                    if child in seen:
+                        continue
+                    child_first_upstream = first_upstream
+                    child_outside_upstream = outside_upstream
+                    if child_first_upstream is None and child not in self.local_roots:
+                        if self.is_upstream_component(child):
+                            child_first_upstream = child
+                        else:
+                            child_outside_upstream = True
+                    if child in targets:
+                        path_count += 1
+                        if child_first_upstream and not child_outside_upstream:
+                            upstream_via.add(child_first_upstream)
+                        else:
+                            actionable_reasons.add("transitive dependency outside configured upstream Micronaut components")
+                    else:
+                        queue.append((child, child_first_upstream, child_outside_upstream, seen | {child}))
+
+        if path_count == 0:
+            return {
+                "classification": "actionable",
+                "reason": "package was present but unreachable from local project roots",
+                "via": [],
+            }
+        if actionable_reasons:
+            return {
+                "classification": "actionable",
+                "reason": "; ".join(sorted(actionable_reasons)),
+                "via": sorted(upstream_via),
+            }
+        return {
+            "classification": "upstream",
+            "reason": "all dependency paths pass through configured upstream Micronaut components",
+            "via": sorted(upstream_via),
+        }
+
+
+def vulnerability_ids(package):
+    ids = []
+    for group in package.get("groups", []):
+        ids.extend(group.get("ids", []))
+    if not ids:
+        ids.extend(vulnerability.get("id") for vulnerability in package.get("vulnerabilities", []))
+    return sorted({vulnerability_id for vulnerability_id in ids if vulnerability_id})
+
+
+def fixed_versions(package):
+    fixed = set()
+    for vulnerability in package.get("vulnerabilities", []):
+        for affected in vulnerability.get("affected", []):
+            for version_range in affected.get("ranges", []):
+                for event in version_range.get("events", []):
+                    if "fixed" in event:
+                        fixed.add(event["fixed"])
+    return sorted(fixed)
+
+
+def iter_packages(osv_results):
+    for result in osv_results.get("results", []):
+        source = result.get("source", {})
+        for package in result.get("packages", []):
+            yield source, package
+
+
+def print_finding(prefix, finding):
+    ids = ", ".join(finding["ids"]) if finding["ids"] else "unknown vulnerability"
+    fixed = ", ".join(finding["fixed_versions"]) if finding["fixed_versions"] else "unknown fixed version"
+    print(f"- {finding['name']}:{finding['version']} ({ids}; fixed: {fixed})")
+    print(f"  {prefix}: {finding['reason']}")
+    if finding["via"]:
+        print(f"  Via: {', '.join(finding['via'])}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Filter OSV findings that are owned by upstream Micronaut components.")
+    parser.add_argument("--sbom", required=True, help="CycloneDX JSON SBOM path")
+    parser.add_argument("--osv", required=True, help="OSV-Scanner JSON output path")
+    parser.add_argument(
+        "--upstream-group-prefixes",
+        default=",".join(DEFAULT_UPSTREAM_GROUP_PREFIXES),
+        help="Comma-separated Maven group prefixes treated as upstream-owned",
+    )
+    args = parser.parse_args()
+
+    upstream_group_prefixes = parse_prefixes(args.upstream_group_prefixes)
+    if not upstream_group_prefixes:
+        print("No upstream group prefixes configured; vulnerability filtering is disabled.", file=sys.stderr)
+        return 1
+
+    graph = AuditGraph(load_json(args.sbom), upstream_group_prefixes)
+    osv_results = load_json(args.osv)
+
+    actionable = []
+    upstream = []
+
+    for source, package_result in iter_packages(osv_results):
+        package = package_result.get("package", {})
+        ecosystem = package.get("ecosystem")
+        name = package.get("name")
+        version = package.get("version")
+        if ecosystem != "Maven" or not name or not version:
+            classification = {
+                "classification": "actionable",
+                "reason": f"unsupported or incomplete package metadata from {source.get('path', 'unknown source')}",
+                "via": [],
+            }
+        else:
+            classification = graph.classify_package(name, version)
+
+        finding = {
+            "name": name or "unknown",
+            "version": version or "unknown",
+            "ids": vulnerability_ids(package_result),
+            "fixed_versions": fixed_versions(package_result),
+            "reason": classification["reason"],
+            "via": classification["via"],
+        }
+        if classification["classification"] == "upstream":
+            upstream.append(finding)
+        else:
+            actionable.append(finding)
+
+    if upstream:
+        print("Upstream-owned vulnerability findings downgraded to informational:")
+        for finding in upstream:
+            print_finding("Reason", finding)
+
+    if actionable:
+        print("Actionable vulnerability findings:")
+        for finding in actionable:
+            print_finding("Reason", finding)
+        return 1
+
+    if not upstream:
+        print("No known vulnerabilities found.")
+    else:
+        print("No locally actionable vulnerabilities found after upstream ownership filtering.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/vulnerability-audit-filter.py
+++ b/.github/scripts/vulnerability-audit-filter.py
@@ -119,11 +119,11 @@ class AuditGraph:
                         actionable_reasons.add("direct local dependency")
                     continue
                 first_upstream = child if self.is_upstream_component(child) else None
-                outside_upstream = child not in self.local_roots and first_upstream is None
-                queue.append((child, first_upstream, outside_upstream, {root, child}))
+                external_before_owner = child not in self.local_roots and first_upstream is None
+                queue.append((child, first_upstream, external_before_owner, {root, child}))
 
             while queue:
-                node, first_upstream, outside_upstream, seen = queue.popleft()
+                node, first_upstream, external_before_owner, seen = queue.popleft()
                 children = self.dependencies.get(node, ())
                 if not children:
                     continue
@@ -131,20 +131,22 @@ class AuditGraph:
                     if child in seen:
                         continue
                     child_first_upstream = first_upstream
-                    child_outside_upstream = outside_upstream
+                    child_external_before_owner = external_before_owner
                     if child_first_upstream is None and child not in self.local_roots:
                         if self.is_upstream_component(child):
                             child_first_upstream = child
                         else:
-                            child_outside_upstream = True
+                            child_external_before_owner = True
                     if child in targets:
                         path_count += 1
-                        if child_first_upstream and not child_outside_upstream:
+                        if child_first_upstream and not child_external_before_owner:
                             upstream_via.add(child_first_upstream)
                         else:
-                            actionable_reasons.add("transitive dependency outside configured upstream Micronaut components")
+                            actionable_reasons.add(
+                                "dependency path reaches a non-local, non-upstream component before a configured upstream owner"
+                            )
                     else:
-                        queue.append((child, child_first_upstream, child_outside_upstream, seen | {child}))
+                        queue.append((child, child_first_upstream, child_external_before_owner, seen | {child}))
 
         if path_count == 0:
             return {
@@ -160,7 +162,7 @@ class AuditGraph:
             }
         return {
             "classification": "upstream",
-            "reason": "all dependency paths pass through configured upstream Micronaut components",
+            "reason": "all dependency paths enter configured upstream Micronaut components before other external components",
             "via": sorted(upstream_via),
         }
 
@@ -214,8 +216,7 @@ def main():
 
     upstream_group_prefixes = parse_prefixes(args.upstream_group_prefixes)
     if not upstream_group_prefixes:
-        print("No upstream group prefixes configured; vulnerability filtering is disabled.", file=sys.stderr)
-        return 1
+        print("No upstream group prefixes configured; no findings will be downgraded.")
 
     graph = AuditGraph(load_json(args.sbom), upstream_group_prefixes)
     osv_results = load_json(args.osv)

--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 readonly CYCLONEDX_GRADLE_PLUGIN_VERSION="${CYCLONEDX_GRADLE_PLUGIN_VERSION:-3.2.4}"
 readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.5@sha256:4d3d1a42ba435ac706286fec518c044f049c9753d21260b5bae60bab8740ed97}"
 readonly SBOM_PATH="${SBOM_PATH:-build/reports/cyclonedx/bom.json}"
+readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
@@ -67,6 +68,8 @@ osv_args=(
     sbom
     --lockfile
     "/src/${SBOM_PATH}"
+    --format
+    json
     --verbosity
     warn
 )
@@ -76,5 +79,23 @@ if [[ -f osv-scanner.toml ]]; then
     osv_args+=(--config /src/osv-scanner.toml)
 fi
 
+osv_output="${tmp_dir}/osv-results.json"
+
 echo "Scanning CycloneDX SBOM with OSV-Scanner"
-docker "${osv_args[@]}"
+set +e
+docker "${osv_args[@]}" > "${osv_output}"
+osv_status=$?
+set -e
+
+if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
+    echo "OSV-Scanner failed with exit code ${osv_status}" >&2
+    if [[ -s "${osv_output}" ]]; then
+        cat "${osv_output}" >&2
+    fi
+    exit "${osv_status}"
+fi
+
+python3 .github/scripts/vulnerability-audit-filter.py \
+    --sbom "${SBOM_PATH}" \
+    --osv "${osv_output}" \
+    --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"

--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -176,6 +176,7 @@ jobs:
             .github/renovate.json
             .github/release.yml
             .github/scripts/vulnerability-audit.sh
+            .github/scripts/vulnerability-audit-filter.py
             .github/ISSUE_TEMPLATE/bug_report.yaml
             .github/ISSUE_TEMPLATE/config.yml
             .github/ISSUE_TEMPLATE/new_feature.yaml

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -24,6 +24,7 @@ on:
       - '.github/workflows/sonatype.yml'
       - '.github/workflows/release.yml'
       - '.github/scripts/vulnerability-audit.sh'
+      - '.github/scripts/vulnerability-audit-filter.py'
 jobs:
   audit:
     if: github.repository != 'micronaut-projects/micronaut-project-template'


### PR DESCRIPTION
## Summary
- run OSV-Scanner in JSON mode and post-filter findings against the CycloneDX dependency graph
- downgrade findings when every path from local project components passes through configured upstream Micronaut components
- sync the new filter helper alongside the shared vulnerability audit script

## Verification
- bash -n .github/scripts/vulnerability-audit.sh
- python syntax compile for .github/scripts/vulnerability-audit-filter.py
- ran patched .github/scripts/vulnerability-audit.sh against micronaut-acme branch issue-157-runtime-account-creation; GHSA-v8h7-rr48-vmmv was downgraded to informational via io.micronaut:micronaut-http-server-netty
- confirmed fail-closed behavior by rerunning the filter with a bogus upstream prefix and observing the finding remain actionable