### PR TITLE
Allow advisory vulnerability audit for prereleases

### DIFF
--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -5,9 +5,15 @@ readonly CYCLONEDX_GRADLE_PLUGIN_VERSION="${CYCLONEDX_GRADLE_PLUGIN_VERSION:-3.2
 readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.5@sha256:4d3d1a42ba435ac706286fec518c044f049c9753d21260b5bae60bab8740ed97}"
 readonly SBOM_PATH="${SBOM_PATH:-build/reports/cyclonedx/bom.json}"
 readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
+readonly VULNERABILITY_AUDIT_ENFORCEMENT="${VULNERABILITY_AUDIT_ENFORCEMENT:-fail}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
+
+if [[ "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "fail" && "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "advisory" ]]; then
+    echo "VULNERABILITY_AUDIT_ENFORCEMENT must be 'fail' or 'advisory'" >&2
+    exit 1
+fi
 
 if [[ ! -x ./gradlew ]]; then
     echo "Gradle wrapper not found or not executable at ${ROOT_DIR}/gradlew" >&2
@@ -95,7 +101,31 @@ if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
     exit "${osv_status}"
 fi
 
+set +e
 python3 .github/scripts/vulnerability-audit-filter.py \
     --sbom "${SBOM_PATH}" \
     --osv "${osv_output}" \
     --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"
+filter_status=$?
+set -e
+
+if [[ ${filter_status} -eq 0 ]]; then
+    exit 0
+fi
+
+if [[ ${filter_status} -eq 1 && "${VULNERABILITY_AUDIT_ENFORCEMENT}" == "advisory" ]]; then
+    message="Actionable vulnerabilities were found, but this milestone/RC release keeps the vulnerability audit advisory."
+    echo "::warning title=Vulnerability audit advisory::${message}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            echo "### Vulnerability audit advisory"
+            echo
+            echo "${message}"
+            echo
+            echo "GA releases and pull request audits remain blocking."
+        } >> "${GITHUB_STEP_SUMMARY}"
+    fi
+    exit 0
+fi
+
+exit "${filter_status}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,15 @@ jobs:
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
-        run: .github/scripts/vulnerability-audit.sh
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: |
+          release_version="${RELEASE_VERSION}"
+          if [[ "${release_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(M|RC)[0-9]+$ ]]; then
+            echo "Running vulnerability audit in advisory mode for ${release_version}"
+            VULNERABILITY_AUDIT_ENFORCEMENT=advisory .github/scripts/vulnerability-audit.sh
+          else
+            .github/scripts/vulnerability-audit.sh
+          fi
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         env:

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -170,6 +170,9 @@ If you are publishing a milestone or release candidate, check the pre-release ch
 
 Note that the release tags must be preceded with `v`, e.g.: `v1.2.3`.
 
+The release workflow runs a vulnerability audit before publishing. Vulnerability findings are advisory for milestone and
+release-candidate tags such as `v1.2.3-M1` and `v1.2.3-RC1`, but they remain blocking for GA releases.
+
 Once you publish the GitHub release, the
 [Release GitHub Action workflow](https://github.com/micronaut-projects/micronaut-project-template/blob/master/.github/workflows/release.yml)
 will kick off, performing the following steps:


### PR DESCRIPTION
## Summary
- Allow milestone and release-candidate release vulnerability audits to proceed in advisory mode when actionable findings are found.
- Keep GA releases, pull request audits, audit tooling failures, malformed scanner/filter output, and non-matching tags fail-closed.
- Document the release-operator behavior in `MAINTAINING.md`.

## Verification
- `bash -n .github/scripts/vulnerability-audit.sh`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "yaml ok #{path}" }' .github/workflows/release.yml .github/workflows/sonatype.yml`
- Focused release-version classification check for milestone/RC, GA, malformed, unrelated, and command-substitution payload strings
- Focused audit-script harness for advisory filter exit `1`, default filter exit `1`, advisory filter exit `2`, and advisory OSV infrastructure exit `2`
- `git diff --check origin/master...HEAD`

## Release Targeting
- Type: `type: improvement`
- Target branch: `master`
- Micronaut organization projects selected during QA intake: `5.0.0-M3` and `5.0.0 Release`
- Ambiguity note: `micronaut-project-template` has no shipped stable release, so the project selection follows the earliest Micronaut Platform release likely to consume the synced template workflow.

Fixes #710

---
###### ✨ This message was AI-generated using gpt-5
