### PR TITLE
Document project template guide basics

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.project-template
 
 title=Micronaut project-template
-projectDesc=TODO
+projectDesc=Repository template for Micronaut module projects
 projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-project-template
 developers=Graeme Rocher

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,1 +1,5 @@
-TODO
+Micronaut Project Template is the repository template used to create and maintain Micronaut module repositories.
+
+It provides the shared Gradle build, documentation scaffold, release automation, issue templates, code style configuration, and GitHub Actions workflows expected by Micronaut projects. New repositories created from this template are cleaned up by the template cleanup workflow so placeholder names such as `project-template` are replaced with the generated repository name.
+
+Use this project when you are creating or updating the common repository structure for Micronaut modules. If you are building a Micronaut application, start with the Micronaut Launch and application guides instead of this maintainer template.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,1 +1,23 @@
-TODO
+To create a new Micronaut module repository from this template:
+
+. Create the repository from `micronaut-projects/micronaut-project-template`.
+. Push the first commit to the new repository.
+. Let the `Template Clean Up` workflow run.
+. Review the cleanup patch and confirm that placeholder names were replaced with the new repository name.
+. Build the generated project locally:
++
+[source,bash]
+----
+./gradlew check
+----
+
+The cleanup workflow rewrites the repository-specific files and renames the placeholder module directories before removing itself from the generated repository.
+
+To work on this template directly, make the change in this repository, then build the guide:
+
+[source,bash]
+----
+./gradlew publishGuide
+----
+
+The generated guide is written to `build/docs/index.html`.


### PR DESCRIPTION
## Summary
- Replace rendered `TODO` placeholders in the Project Template guide introduction and quick start.
- Set the project description metadata used in the generated guide header.
- Keep the guidance scoped to Micronaut module maintainers and the existing template cleanup workflow.

## Validation
- `./gradlew publishGuide`
- Verified the rendered guide output no longer contains `TODO` in the guide header, Introduction, or Quick Start.

Paperclip: DEV-278, DEV-276

---
###### ✨ This message was AI-generated using gpt-5.5
