### PR TITLE
Replace Project Template guide placeholders

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.project-template
 
 title=Micronaut project-template
-projectDesc=TODO
+projectDesc=Template repository for new Micronaut module projects
 projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-project-template
 developers=Graeme Rocher

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,1 +1,5 @@
-TODO
+Micronaut Project Template is the template repository used to start new Micronaut module projects.
+
+The repository provides the baseline Gradle build, module and BOM project layout, documentation structure, release workflows, issue templates, license and maintenance files expected by Micronaut projects.
+
+It also acts as the source of truth for common project files that are synchronized into existing Micronaut repositories. Changes to shared workflow files, Gradle wrapper files, issue templates, maintenance files, and shared configuration should therefore be made here when the same change is intended for the wider Micronaut project set.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,1 +1,15 @@
-TODO
+Use this repository when creating or maintaining a Micronaut module repository.
+
+To create a new module repository, start from the GitHub template repository at https://github.com/{githubSlug}[https://github.com/{githubSlug}].
+When the generated repository receives its first push, the template cleanup workflow updates template-specific names and repository links in the files it edits, renames the starter module and BOM directories, and removes the cleanup workflow from the generated repository.
+
+After cleanup, review the generated repository before opening it for normal development:
+
+* confirm `gradle.properties` contains the correct project name, group, description, and GitHub slug
+* confirm the module and BOM directory names match the new repository
+* replace any remaining project-specific wording in `README.md`, `CONTRIBUTING.md`, and guide files
+* run `./gradlew check` to verify the generated build
+* run `./gradlew publishGuide` to verify the generated user guide
+
+To update shared files for existing Micronaut repositories, change the source files in this template repository.
+The `Files sync` workflow can then open synchronization pull requests for the configured target repositories.


### PR DESCRIPTION
## Summary

- replace the generated guide TODO introduction with source-backed Project Template purpose text
- replace the Quick Start TODO with template creation, cleanup, and file sync guidance
- replace the generated project description TODO so the guide landing page no longer renders placeholder text

## Validation

- `./gradlew publishGuide`
- `./gradlew docs`
- disposable local cleanup simulation using `GITHUB_REPOSITORY=micronaut-projects/micronaut-example` verified the cleanup workflow renames the starter module/BOM directories, renames the buildSrc convention plugins, updates repository links in edited files, and removes `template-cleanup.yml`

---
###### ✨ This message was AI-generated using gpt-5.5