### PR TITLE
Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   central-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -11,6 +11,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -28,6 +30,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -17,6 +17,8 @@ jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -34,6 +36,9 @@ jobs:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: ['25']

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove system JDKs
         run: |

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -29,6 +29,8 @@ jobs:
   audit:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         java: ['25']


### PR DESCRIPTION
Fixes #673.

## Summary
- Add explicit `contents: read` permissions to read-only synced workflow jobs.
- Add `checks: write` only to workflow jobs that publish JUnit check runs.
- Keep matrix/bootstrap jobs read-only while preserving existing workflow behavior.

## Verification
- `git diff --check origin/master...HEAD`
- Parsed all six edited workflow YAML files with Python/PyYAML.

---
###### ✨ This message was AI-generated using gpt-5.5