### PR TITLE
Improve GraalVM native test diagnostics

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -65,6 +65,7 @@ jobs:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GRAALVM_QUICK_BUILD: true
+          NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
         with:
           nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps

--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -51,7 +51,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Pre-Build Steps
-        uses: micronaut-projects/github-actions/graalvm/pre-build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
+        uses: micronaut-projects/github-actions/graalvm/pre-build@9fefbe9a777a84ac4211027f613521ed22f4cd93 # master
         id: pre-build
         with:
           java: ${{ matrix.java }}

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -68,6 +68,7 @@ jobs:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GRAALVM_QUICK_BUILD: true
+          NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
         with:
           nativeTestTask: ${{ matrix.native_test_task }}
       - name: Post-Build Steps

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -47,7 +47,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Pre-Build Steps
-        uses: micronaut-projects/github-actions/graalvm/pre-build@300bf6db7c062dcba77c90bb90e475df31b2acab # master
+        uses: micronaut-projects/github-actions/graalvm/pre-build@9fefbe9a777a84ac4211027f613521ed22f4cd93 # master
         id: pre-build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,6 +51,7 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
 
       - name: "🔧 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -62,6 +62,7 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
 
       - name: "🔧 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6


### PR DESCRIPTION
## Summary
- pass `NATIVE_IMAGE_OPTIONS="-H:+ReportExceptionStackTraces"` into the GraalVM native test build steps
- enable `native-image-job-reports: true` on the direct `graalvm/setup-graalvm` workflow steps owned by this repository
- update the native-test `graalvm/pre-build` action pin to the merged companion action revision

## Review Notes
- Target branch: `master`.
- Release target: default-branch maintenance; CI/workflow diagnostics only, non-breaking.
- Micronaut organization projects selected during QA: `5.0.0-M3` and `5.0.0 Release`.
- Project-selection ambiguity carried from QA: `micronaut-project-template` does not map cleanly to a module artifact release consumed directly by the Micronaut Platform BOM, so the selected projects follow the current default-branch Micronaut Platform line.
- The native-test workflows invoke `graalvm/setup-graalvm` through the pinned `micronaut-projects/github-actions/graalvm/pre-build` composite action. Companion PR micronaut-projects/github-actions#53 was merged on 2026-05-21 and enables `native-image-job-reports: true` in that shared action.
- The `graalvm/pre-build` references in this PR now point at merged companion commit `9fefbe9a777a84ac4211027f613521ed22f4cd93`.

## Verification
- Parsed the edited workflow YAML with Ruby `YAML.load_file`.
- Ran targeted assertions for the added `NATIVE_IMAGE_OPTIONS` and `native-image-job-reports` values.
- Ran `git diff --check origin/master...HEAD`.
- Confirmed companion PR micronaut-projects/github-actions#53 is merged.
- Parsed the native-test workflows after updating the `graalvm/pre-build` pin and confirmed both references point at `9fefbe9a777a84ac4211027f613521ed22f4cd93`.

## PR Assets
- None required; this is a workflow-only diagnostics change with no rendered or generated artifacts.

Fixes #722

---
###### ✨ This message was AI-generated using gpt-5