### PR TITLE
Update coding skill API documentation guidance

### DIFF
--- a/.agents/skills/coding/SKILL.md
+++ b/.agents/skills/coding/SKILL.md
@@ -36,7 +36,7 @@ Should not trigger:
 1. Establish scope and API impact.
 2. Implement Java code with Micronaut maintainer conventions.
 3. Enforce API boundaries and binary compatibility.
-4. Document public Java APIs.
+4. Document Java APIs and implementation intent.
 5. Keep Gradle/build changes aligned with repository conventions.
 6. Verify with maintainer-grade checks before completion.
 
@@ -74,13 +74,15 @@ Should not trigger:
 - Keep visibility as narrow as possible for non-public internals.
 - When deprecating API, provide migration-friendly Javadoc and avoid silent behavioral breaks.
 
-### 4) Document public Java APIs
+### 4) Document Java APIs and implementation intent
 
 - All public Java types and public methods must have Javadoc. Include public constructors when they are part of the user-facing API.
 - All new public Java types, methods, and user-facing constructors must include an `@since` Javadoc tag for the version where the PR will debut.
 - Determine the `@since` version from the approved target branch, not from guesswork. Inspect that branch's `gradle.properties` (`projectVersion`) and use the corresponding release version; for example, `4.9.0-SNAPSHOT` means the new API debuts in `4.9.0`.
 - If the PR is retargeted during follow-through, re-check the target branch's `gradle.properties` and update any newly added `@since` tags when the debut version changes.
 - Do not add `@since` tags to internal-only APIs annotated with `@Internal` unless the repository already does so for that internal package.
+- Internal and package-private methods should include maintainer-focused Javadoc when the implementation contract, lifecycle, invariants, or generated-code interaction is not obvious from the signature.
+- Complex new code should include focused inline comments that explain implementation decisions or invariants; do not narrate straightforward control flow.
 
 ### 5) Keep Gradle/build changes convention-aligned
 
@@ -147,6 +149,7 @@ When finishing implementation work, report:
 - [ ] API boundary guidance includes `@Internal`, `@Experimental`, `@UsedByGeneratedCode`, and compatibility checks.
 - [ ] Public Java types and methods require Javadoc.
 - [ ] New public Java APIs require `@since` tags derived from the approved target branch's `gradle.properties`.
+- [ ] Internal/package-private methods and complex new code include maintainer-focused Javadoc or inline comments when implementation intent is not obvious.
 - [ ] For public API evolution without breaking changes, deprecations include clear replacement guidance and functional compatibility is preserved.
 - [ ] If breaking changes are allowed, user guide docs in `src/main/docs/guide` are updated with migration notes.
 - [ ] Verification includes tests, style checks, `check`, and `docs`.

--- a/.agents/skills/coding/SKILL.md
+++ b/.agents/skills/coding/SKILL.md
@@ -37,7 +37,8 @@ Should not trigger:
 2. Implement Java code with Micronaut maintainer conventions.
 3. Enforce API boundaries and binary compatibility.
 4. Keep Gradle/build changes aligned with repository conventions.
-5. Verify with maintainer-grade checks before completion.
+5. Verify API documentation and `@since` coverage for public Java APIs.
+6. Verify with maintainer-grade checks before completion.
 
 ### 1) Establish scope and API impact
 
@@ -73,7 +74,15 @@ Should not trigger:
 - Keep visibility as narrow as possible for non-public internals.
 - When deprecating API, provide migration-friendly Javadoc and avoid silent behavioral breaks.
 
-### 4) Keep Gradle/build changes convention-aligned
+### 4) Document public Java APIs
+
+- All public Java types and public methods must have Javadoc. Include public constructors when they are part of the user-facing API.
+- All new public Java types, methods, and user-facing constructors must include an `@since` Javadoc tag for the version where the PR will debut.
+- Determine the `@since` version from the approved target branch, not from guesswork. Inspect that branch's `gradle.properties` (`projectVersion`) and use the corresponding release version; for example, `4.9.0-SNAPSHOT` means the new API debuts in `4.9.0`.
+- If the PR is retargeted during follow-through, re-check the target branch's `gradle.properties` and update any newly added `@since` tags when the debut version changes.
+- Do not add `@since` tags to internal-only APIs annotated with `@Internal` unless the repository already does so for that internal package.
+
+### 5) Keep Gradle/build changes convention-aligned
 
 - Use `./gradlew` for all Gradle execution.
 - Use Gradle version catalogs (`gradle/libs.versions.toml`) instead of hard-coded dependency versions.
@@ -81,7 +90,7 @@ Should not trigger:
 - Do not add custom build logic directly in module build files when it belongs in convention plugins.
 - When uncertain about module paths, use `./gradlew projects` and prefer canonical `micronaut-*` project names.
 
-### 5) Verify before completion
+### 6) Verify before completion
 
 First confirm canonical verification tasks from `CONTRIBUTING.md` and existing CI/build files, then run the repository equivalents from root.
 
@@ -126,8 +135,9 @@ When finishing implementation work, report:
 3. Semantic Versioning impact classification (patch/minor/major) for any public-facing change.
 4. For deprecate-and-add API evolution, which elements were deprecated and which replacement variants were introduced.
 5. For breaking public-facing changes, which user guide files were updated and what migration guidance was added.
-6. Commands executed for verification and outcomes.
-7. Any follow-up risk (for example compatibility implications).
+6. For new public Java APIs, the `@since` version used and how it was derived from the target branch's `gradle.properties`.
+7. Commands executed for verification and outcomes.
+8. Any follow-up risk (for example compatibility implications).
 
 ## Validation Checklist
 
@@ -135,6 +145,8 @@ When finishing implementation work, report:
 - [ ] Guidance is maintainer-focused (not end-user app guidance).
 - [ ] Java conventions include JSpecify nullability (`@NullMarked`, `@Nullable`), DI, and reflection-free guidance.
 - [ ] API boundary guidance includes `@Internal`, `@Experimental`, `@UsedByGeneratedCode`, and compatibility checks.
+- [ ] Public Java types and methods require Javadoc.
+- [ ] New public Java APIs require `@since` tags derived from the approved target branch's `gradle.properties`.
 - [ ] For public API evolution without breaking changes, deprecations include clear replacement guidance and functional compatibility is preserved.
 - [ ] If breaking changes are allowed, user guide docs in `src/main/docs/guide` are updated with migration notes.
 - [ ] Verification includes tests, style checks, `check`, and `docs`.

--- a/.agents/skills/coding/SKILL.md
+++ b/.agents/skills/coding/SKILL.md
@@ -36,8 +36,8 @@ Should not trigger:
 1. Establish scope and API impact.
 2. Implement Java code with Micronaut maintainer conventions.
 3. Enforce API boundaries and binary compatibility.
-4. Keep Gradle/build changes aligned with repository conventions.
-5. Verify API documentation and `@since` coverage for public Java APIs.
+4. Document public Java APIs.
+5. Keep Gradle/build changes aligned with repository conventions.
 6. Verify with maintainer-grade checks before completion.
 
 ### 1) Establish scope and API impact


### PR DESCRIPTION
## Summary

- Require Javadoc for public Java types and methods in the Micronaut coding skill.
- Require `@since` for new public Java APIs and derive the debut version from the approved target branch's `gradle.properties` `projectVersion`.
- Preserve the existing JSpecify nullability and API-boundary guidance while adding the new documentation checks.

## Verification

- `git rebase origin/master`
- `git diff --check origin/master...HEAD`
- `npx --yes agent-skills-cli@1.1.7 validate .agents/skills/coding`
- `npx --yes agent-skills-cli@1.1.7 audit .agents/skills/coding --fail-on high --format summary`
- `npx skills list`

## Paperclip

- Paperclip issue: DEV-874
- Linked GitHub issue: none found, so no closing keyword or issue-creator reviewer request applies.
- PR-visible assets: not required; this is a Markdown-only agent skill guidance change.

---
###### ✨ This message was AI-generated using gpt-5
