### PR TITLE
Pin write-token GitHub Actions refs

### DIFF
--- a/.github/workflows/files-sync.yml
+++ b/.github/workflows/files-sync.yml
@@ -8,6 +8,10 @@ on:
         type: string
   schedule:
     - cron: '0 5 * * *'
+
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     if: github.repository == 'micronaut-projects/micronaut-project-template'
@@ -132,11 +136,11 @@ jobs:
         repo: ${{ fromJson(needs.prepare-matrix.outputs.repos) }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: source
       - name: Checkout target - default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: micronaut-projects/micronaut-${{ matrix.repo }}
           path: target
@@ -210,7 +214,7 @@ jobs:
         shell: bash
       - name: Create Pull Request - ${{ steps.branch.outputs.branch }}
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           path: target
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/skills-validation.yml
+++ b/.github/workflows/skills-validation.yml
@@ -18,10 +18,10 @@ jobs:
       AGENT_SKILLS_CLI_VERSION: "1.1.7"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 


### PR DESCRIPTION
## Summary

- Pin mutable GitHub Actions refs in project-template workflows.
- Add least-privilege top-level permissions where the implementation branch changed workflow files.

## Verification From Paperclip DEV-508

- YAML parsing passed for changed workflows.
- Mutable-ref grep returned no matches for workflow action uses.

Paperclip issue: DEV-508

---
###### ✨ This message was AI-generated using gpt-5.5
