### PR TITLE
Add build job name to gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,7 @@ on:
       - '[0-9]+.[0-9]+.x'
 jobs:
   build:
+    name: "build"
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
According to the documentation:

> The name of the job displayed on GitHub.

I don't know if GitHup will append the matrix value again