### PR TITLE
Clarify generated app validation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ To get a local development version of Micronaut project-template working, first 
 ./gradlew pTML
 ```
 
+After changing the template, create a generated application that consumes this local version and run its tests to verify the generated project still builds.
+
 You can then reference the version specified with `projectVersion` in `gradle.properties` in a test project's `build.gradle` or `pom.xml`. If you use Gradle, add the `mavenLocal` repository (Maven automatically does this):
 
 ```


### PR DESCRIPTION
## Summary
- Clarifies that template changes should be validated by generating an application that consumes the locally published template version and running that app's tests.

## Implementation notes
- Docs-only change in `CONTRIBUTING.md` next to the existing `publishToMavenLocal` guidance.
- Paperclip issue: DEV-1398.

## Verification
- `git diff --check`
- Not run: Gradle build/docs tasks, because this is a single prose-only `CONTRIBUTING.md` change that is not build-validated.

---
###### ✨ This message was AI-generated using gpt-5.5
