### PR TITLE
Clarify generated app template validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Micronaut project-template
 
 See the [Documentation](https://micronaut-projects.github.io/micronaut-project-template/latest/guide/) for more information.
 
+After changing template files, validate a generated application by creating a repository from this template and running `./gradlew check` in the generated project.
+
 See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-project-template/snapshot/guide/) for the current development docs.
 
 <!-- ## Examples


### PR DESCRIPTION
## Summary
- Clarifies that template changes should be validated by creating a generated repository and running `./gradlew check` there.
- Keeps the change docs-only and limited to the README.

## Verification
- `git diff --check`
- `./gradlew --version` (confirms local Gradle/JDK setup for this docs-only change)

Headroom pilot comparison run for DEV-1397.

---
###### ✨ This message was AI-generated using gpt-5.5
